### PR TITLE
implement run snafu fio wrapper

### DIFF
--- a/fio_wrapper/fio_analyzer.py
+++ b/fio_wrapper/fio_analyzer.py
@@ -10,10 +10,9 @@ class Fio_Analyzer:
     results are analyzed based on operation and io size, this is a static evaluation and future enhancements could evalute results based on
     other properties dynamically.
     """
-    def __init__(self, uuid, user, prefix, cluster_name):
+    def __init__(self, uuid, user, cluster_name):
         self.uuid = uuid
         self.user = user
-        self.prefix = prefix
         self.fio_processed_results_list = []
         self.sample_list = []
         self.operation_list = []
@@ -133,5 +132,5 @@ class Fio_Analyzer:
                 importdoc['ceph_benchmark_test']['test_data'] = tmp_doc
                 importdoc['cluster_name'] = self.cluster_name
                 #TODO add ID to document
-                index = self.prefix + "-analyzed-result"
+                index = "-analyzed-result"
                 yield importdoc, index

--- a/fio_wrapper/fio_wrapper.py
+++ b/fio_wrapper/fio_wrapper.py
@@ -15,174 +15,86 @@
 # per_job_logs=true
 #
 import os
-import sys
-# in order to run need to add parent dir to sys.path
-parent_dir = os.path.abspath(os.path.join(__file__ ,"../.."))
-sys.path.append(parent_dir)
-
 import argparse
 import configparser
-import elasticsearch
-import time, datetime
 import logging
-import hashlib
-import json
-from copy import deepcopy
+
 from fio_analyzer import Fio_Analyzer
-from utils.py_es_bulk import streaming_bulk
-from utils.common_logging import setup_loggers
 import trigger_fio
 
-logger = logging.getLogger("fio_wrapper")
+logger = logging.getLogger("snafu")
 
-es_log = logging.getLogger("elasticsearch")
-es_log.setLevel(logging.CRITICAL)
-urllib3_log = logging.getLogger("urllib3")
-urllib3_log.setLevel(logging.CRITICAL)
+class fio_wrapper():
 
-setup_loggers("fio_wrapper", logging.DEBUG)
-
-
-def main():
-
-    #collect arguments
-    parser = argparse.ArgumentParser(description="fio-d Wrapper script")
-    parser.add_argument(
-        'hosts', help='Provide host file location')
-    parser.add_argument(
-        'job', help='path to job file')
-    parser.add_argument(
-        '-s', '--sample', type=int, default=1, help='number of times to run benchmark, defaults to 1')
-    parser.add_argument(
-        '-d', '--dir', help='output parent directory', default=os.path.dirname(os.getcwd()))
-    parser.add_argument(
-        '-hp', '--histogramprocess', help='Process and index histogram results', default=False)
-    args = parser.parse_args()
-
-    args.index_results = False
-    args.prefix = "ripsaw-fio-"
-    es={}
-    # set up a standard format for time
-    FMT = '%Y-%m-%dT%H:%M:%SGMT'
-    args.cluster_name = "mycluster"
-    if "clustername" in os.environ:
-        args.cluster_name = os.environ["clustername"]
-    #if using elasticsearch use streaming bulk, else bypass indexing
-    if "es" in os.environ:
-        es['server'] = os.environ["es"]
-        es['port'] = os.environ["es_port"]
-        args.prefix = os.environ["es_index"]
-        if len(es['server']) > 0 and len(es['port']) > 0 and len(args.prefix) > 0:
-            args.index_results = True
-
-        es = elasticsearch.Elasticsearch([
-        {'host': es['server'],'port': es['port'] }],send_get_body_as='POST')
-        if not es.ping():
-            logger.warn("Elasticsearch connection failed or passed incorrectly, turning off indexing")
-            args.index_results = False
-
-        #call py es bulk using a process generator to feed it ES documents
-        res_beg, res_end, res_suc, res_dup, res_fail, res_retry  = streaming_bulk(es, process_generator(args))
-    
-        logger.info("Indexed results - %s success, %s duplicates, %s failures, with %s retries." % (res_suc,
-                                                                                                res_dup,
-                                                                                                res_fail,
-                                                                                                res_retry))
-        start_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime(res_beg))
-        end_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime(res_end))
-    else:
-        start_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime())
-        #need to loop through generator and pass on all yields
-        #this will execute all jobs without elasticsearch
-        for i in process_generator(args):
-            pass
-        end_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime())
+    def __init__(self, parser):
+        #collect arguments
         
-    start_t = datetime.datetime.strptime(start_t, FMT)
-    end_t = datetime.datetime.strptime(end_t, FMT)
-
-    #get time delta for indexing run
-    tdelta = end_t - start_t
-    logger.info("Duration of indexing - %s" % tdelta)
+        #parser = argparse.ArgumentParser(description="fio-d Wrapper script")
+        parser.add_argument(
+            '-H', '--hosts', help='Provide host file location')
+        parser.add_argument(
+            '-j', '--job', help='path to job file')
+        parser.add_argument(
+            '-s', '--sample', type=int, default=1, help='number of times to run benchmark, defaults to 1')
+        parser.add_argument(
+            '-d', '--dir', help='output parent directory', default=os.path.dirname(os.getcwd()))
+        parser.add_argument(
+            '-hp', '--histogramprocess', help='Process and index histogram results', default=False)
+        self.args = parser.parse_args()
     
-
-def process_generator(args):
-
-    object_generator = process_data(args)
-
-    for object in object_generator:
-        for action, index in object.emit_actions():
-
-            es_valid_document = { "_index": index,
-                                  "_type": "_doc",
-                                  "_op_type": "create",
-                                  "_source": action,
-                                  "_id": "" }
-            es_valid_document["_id"] = hashlib.md5(str(action).encode()).hexdigest()
-            #logger.debug(json.dumps(es_valid_document, indent=4))
-            yield es_valid_document
-
-def process_data(args):
-    uuid = ""
-    user = ""
-    server = ""
-
-    index_results = args.index_results
-
-    if "uuid" in os.environ:
-        uuid = os.environ["uuid"]
-    if "test_user" in os.environ:
-        user = os.environ["test_user"]
-    # if "pod_details" in os.environ:
-    #     hosts_metadata = os.environ["pod_details"]
-    sample = args.sample
-    working_dir = args.dir
-    host_file_path = args.hosts
-    _fio_job_dict = _parse_jobfile(args.job)
-    fio_job_names = _fio_job_dict.sections()
-    if 'global' in fio_job_names:
-        fio_job_names.remove('global')
-    fio_jobs_dict = _parse_jobs(_fio_job_dict, fio_job_names)
-    document_index_prefix = args.prefix
-
-    fio_analyzer_obj = Fio_Analyzer(uuid, user, document_index_prefix, args.cluster_name)
-    #execute fio for X number of samples, yield the trigger_fio_generator
-    for i in range(1, sample + 1):
-        sample_dir = working_dir + '/' + str(i)
-        if not os.path.exists(sample_dir):
-            os.mkdir(sample_dir)
-        trigger_fio_generator = trigger_fio._trigger_fio(fio_job_names,
-                                                         args.cluster_name,
-                                                         sample_dir,
-                                                         fio_jobs_dict,
-                                                         host_file_path,
-                                                         user,
-                                                         uuid,
-                                                         i,
-                                                         fio_analyzer_obj,
-                                                         document_index_prefix,
-                                                         index_results,
-                                                         args.histogramprocess)
-        yield trigger_fio_generator
+        self.args.cluster_name = "mycluster"
+        if "clustername" in os.environ:
+            self.args.cluster_name = os.environ["clustername"]
     
-    #if indexing data into elasticsearch will fio_analyzer
-    #else do not
-    if index_results:
-        logger.info("Indexing analyzed fio data")
+        self.uuid = ""
+        self.user = ""
+        self.server = ""
+    
+        if "uuid" in os.environ:
+            self.uuid = os.environ["uuid"]
+        if "test_user" in os.environ:
+           self.user = os.environ["test_user"]
+        # if "pod_details" in os.environ:
+        #     hosts_metadata = os.environ["pod_details"]
+        self.sample = self.args.sample
+        self.working_dir = self.args.dir
+        self.host_file_path = self.args.hosts
+        self._fio_job_dict = self._parse_jobfile(self.args.job)
+        self.fio_job_names = self._fio_job_dict.sections()
+        if 'global' in self.fio_job_names:
+            self.fio_job_names.remove('global')
+        self.fio_jobs_dict = self._parse_jobs(self._fio_job_dict, self.fio_job_names)
+    
+    def run(self):
+        fio_analyzer_obj = Fio_Analyzer(self.uuid, self.user, self.args.cluster_name)
+        #execute fio for X number of samples, yield the trigger_fio_generator
+        for i in range(1, self.sample + 1):
+            sample_dir = self.working_dir + '/' + str(i)
+            if not os.path.exists(sample_dir):
+                os.mkdir(sample_dir)
+            trigger_fio_generator = trigger_fio._trigger_fio(self.fio_job_names,
+                                                             self.args.cluster_name,
+                                                             sample_dir,
+                                                             self.fio_jobs_dict,
+                                                             self.host_file_path,
+                                                             self.user,
+                                                             self.uuid,
+                                                             i,
+                                                             fio_analyzer_obj,
+                                                             self.args.histogramprocess)
+            yield trigger_fio_generator
+    
         yield fio_analyzer_obj
-
-def _parse_jobs(job_dict, jobs):
-    job_dicts = {}
-    if 'global' in job_dict.keys():
-        job_dicts['global'] = dict(job_dict['global'])
-    for job in jobs:
-        job_dicts[job] = dict(job_dict[job])
-    return job_dicts
-
-def _parse_jobfile(job_path):
-    config = configparser.ConfigParser(allow_no_value=True)
-    config.read(job_path)
-    return config
-
-if __name__ == '__main__':
-    sys.exit(main())
+    
+    def _parse_jobs(self, job_dict, jobs):
+        job_dicts = {}
+        if 'global' in job_dict.keys():
+            job_dicts['global'] = dict(job_dict['global'])
+        for job in jobs:
+            job_dicts[job] = dict(job_dict[job])
+        return job_dicts
+    
+    def _parse_jobfile(self, job_path):
+        config = configparser.ConfigParser(allow_no_value=True)
+        config.read(job_path)
+        return config

--- a/run_snafu.py
+++ b/run_snafu.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# This wrapper assumes the following in fiojob
+# per_job_logs=true
+#
+import os
+import sys
+import argparse
+import configparser
+import elasticsearch
+import time, datetime
+import logging
+import hashlib
+import json
+from utils.py_es_bulk import streaming_bulk
+from utils.common_logging import setup_loggers
+from utils.wrapper_factory import wrapper_factory
+
+logger = logging.getLogger("snafu")
+
+#mute elasticsearch and urllib3 logging
+es_log = logging.getLogger("elasticsearch")
+es_log.setLevel(logging.CRITICAL)
+urllib3_log = logging.getLogger("urllib3")
+urllib3_log.setLevel(logging.CRITICAL)
+
+setup_loggers("snafu", logging.DEBUG)
+
+def main():
+    
+    #collect arguments
+    parser = argparse.ArgumentParser(description="run script")
+    parser.add_argument(
+        '-t', '--tool', action='store', dest='tool', help='Provide tool name')
+    index_args, unknown = parser.parse_known_args()
+    index_args.index_results = False
+    index_args.prefix = "snafu-%s" % index_args.tool
+    # set up a standard format for time
+    FMT = '%Y-%m-%dT%H:%M:%SGMT'
+    
+    #instantiate elasticsearch instance and check connection 
+    es={}
+    if "es" in os.environ:
+        es['server'] = os.environ["es"]
+        es['port'] = os.environ["es_port"]
+        index_args.prefix = "%s-%s" % (os.environ["es_index"], index_args.tool)
+        index_args.index_results = True
+    
+        es = elasticsearch.Elasticsearch([
+        {'host': es['server'],'port': es['port'] }],send_get_body_as='POST')
+    
+    if not es.ping():
+        logger.warn("Elasticsearch connection failed or passed incorrectly, turning off indexing")
+        index_args.index_results = False
+    
+    if index_args.index_results:
+        #call py es bulk using a process generator to feed it ES documents
+        res_beg, res_end, res_suc, res_dup, res_fail, res_retry  = streaming_bulk(es, process_generator(index_args, parser))
+               
+        logger.info("Indexed results - %s success, %s duplicates, %s failures, with %s retries." % (res_suc,
+                                                                                                    res_dup,
+                                                                                                    res_fail,
+                                                                                                    res_retry)) 
+
+        start_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime(res_beg))
+        end_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime(res_end))
+
+    else:
+        start_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime())
+        #need to loop through generator and pass on all yields
+        #this will execute all jobs without elasticsearch
+        for i in process_generator(index_args, parser):
+            pass
+        end_t = time.strftime('%Y-%m-%dT%H:%M:%SGMT', time.gmtime())
+
+    
+    start_t = datetime.datetime.strptime(start_t, FMT)
+    end_t = datetime.datetime.strptime(end_t, FMT)
+    
+    #get time delta for indexing run
+    tdelta = end_t - start_t
+    logger.info("Duration of execution - %s" % tdelta)
+
+
+
+def process_generator(index_args, parser):
+    
+    benchmark_wrapper_object_generator = generate_wrapper_object(index_args, parser)
+    
+    for wrapper_object in benchmark_wrapper_object_generator:
+        for data_object in wrapper_object.run():
+            for action, index in data_object.emit_actions():
+                
+                es_index = index_args.prefix + index
+                es_valid_document = { "_index": es_index,
+                                      "_type": "_doc",
+                                      "_op_type": "create",
+                                      "_source": action,
+                                      "_id": "" }
+                es_valid_document["_id"] = hashlib.md5(str(action).encode()).hexdigest()
+                #logger.debug(json.dumps(es_valid_document, indent=4))
+                yield es_valid_document
+
+def generate_wrapper_object(index_args, parser):
+
+    benchmark_wrapper_object = wrapper_factory(index_args.tool, parser)
+
+    yield benchmark_wrapper_object
+
+if __name__ == '__main__':
+    sys.exit(main())
+    

--- a/utils/wrapper_factory.py
+++ b/utils/wrapper_factory.py
@@ -1,0 +1,25 @@
+
+#from backpack_wrapper.backpack_wrapperimport backpack_wrapper
+from fio_wrapper.fio_wrapper import fio_wrapper
+#from pgbench_wrapper.pgbench_wrapper import pgbench_wrapper
+#from uperf_wrapper.uperf_wrapper import uperf_wrapper
+
+import logging
+logger = logging.getLogger("snafu")
+
+wrapper_dict = {"fio": fio_wrapper}
+#    "backpack": pgbench_wrapper,
+#    "fio": fio_wrapper,
+#    "pgbench": pgbench_wrapper,
+#    "uperf": uperf_wrapper
+#    }
+
+def wrapper_factory(tool_name, parser):
+    try:
+        wrapper = wrapper_dict[tool_name]
+        logger.info("identified %s as the benchmark wrapper" % tool_name) 
+    except KeyError:
+        logger.error("Tool name %s is not recognized." % tool_name)
+        return 1 #if error return 1 and fail
+    else:
+        return wrapper(parser)


### PR DESCRIPTION
This PR implements run snafu and updates fio wrapper to be compatible. 

run_snafu.py expects a single argument:
-t

fio_wrapper will parse the remaining arguments and expects the following arguments:
-H <host file>
-j <job file>
-s <samples>
-d <outpud directory>

how to run example:

`run_snafu.py -t fio -H /tmp/host/hosts -j /tmp/fio/fiojob-file -s 2 -d /tmp/ouput_dir`

This PR attempts to resolve part of issue #24 Inefficient indexing.