### PR TITLE
Adding dockerfiles from magazine into snafu

### DIFF
--- a/ceph-cache-dropper/Dockerfile
+++ b/ceph-cache-dropper/Dockerfile
@@ -1,0 +1,5 @@
+FROM rook/ceph:master
+
+USER root
+RUN yum install -y git
+COPY snafu /opt/snafu

--- a/fio_wrapper/Dockerfile
+++ b/fio_wrapper/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos/tools
+
+USER root
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y yum-plugin-copr
+RUN yes | yum copr enable ndokos/pbench
+RUN yum install -y pbench-fio
+RUN yum install -y git python-pip
+RUN pip install --upgrade pip
+RUN pip install elasticsearch numpy configparser statistics
+COPY snafu /opt/snafu

--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos/tools
+MAINTAINER Ben England <bengland@redhat.com>
+
+RUN rpm -iv https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y git python-elasticsearch6 python-redis python2-numpy
+RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift
+COPY snafu /opt/snafu

--- a/hammerdb/Dockerfile
+++ b/hammerdb/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos/tools
+
+# install requirements
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y expect python-elasticsearch wget tcl unixODBC-devel unixODBC
+
+# install packages required for ms-sql
+RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
+RUN ACCEPT_EULA=Y yum -y install msodbcsql17
+RUN ACCEPT_EULA=Y yum -y install msodbcsql
+RUN yum remove -y unixODBC-utf16 unixODBC-utf16-devel && yum -y clean all
+RUN yum clean all -y
+
+# clone the snafu repo
+#RUN git clone https://github.com/mkarg75/snafu.git
+# Download and install the hammer suite
+
+RUN wget 'https://downloads.sourceforge.net/project/hammerdb/HammerDB/HammerDB-3.2/HammerDB-3.2-Linux-x86-64-Install?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fhammerdb%2Ffiles%2FHammerDB%2FHammerDB-3.2%2FHammerDB-3.2-Linux-x86-64-Install%2Fdownload&ts=1564587940&use_mirror=autoselect' -O hammer_installer
+RUN mkdir /hammer
+RUN chmod 755 hammer_installer
+RUN ./hammer_installer --prefix /hammer --mode silent
+
+COPY hammerdb/uid_entrypoint /usr/local/bin/
+
+RUN chmod g+w /etc/passwd
+RUN chmod 755 /usr/local/bin/uid_entrypoint
+RUN /usr/local/bin/uid_entrypoint

--- a/hammerdb/uid_entrypoint
+++ b/hammerdb/uid_entrypoint
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ `id -u` -ge 10000 ]
+then
+#cat /etc/passwd | sed -e "s/^$NB_USER:/builder:/" > tmppasswd
+echo "$UID:x:`id -u`:`id -g`:,,,:/home/$UID:/bin/bash" >> /etc/passwd
+#rm tmppasswd
+fi

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos/tools
+
+USER root
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y iperf3

--- a/pbench-agent/Dockerfile
+++ b/pbench-agent/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos/tools
+
+USER root
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN curl -s https://copr.fedorainfracloud.org/coprs/ndokos/pbench/repo/epel-7/ndokos-pbench-epel-7.repo > /etc/yum.repos.d/copr-pbench.repo
+RUN yum install -y redis
+RUN yum --enablerepo=ndokos-pbench install -y pbench-agent
+RUN yum --enablerepo=ndokos-pbench install -y pbench-sysstat

--- a/pgbench-wrapper/Dockerfile
+++ b/pgbench-wrapper/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos/tools
+
+USER root
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN yum -y update
+RUN yum install -y postgresql11
+RUN yum install -y redis
+RUN yum install -y git python-pip
+RUN pip install --upgrade pip
+RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
+RUN yum install -y numpy
+RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
+COPY snafu /opt/snafu

--- a/smallfile_wrapper/Dockerfile
+++ b/smallfile_wrapper/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos/tools
+
+USER root
+WORKDIR /root/
+RUN yum install git epel-release -y
+RUN yum install python2-elasticsearch python2-numpy python2-configparser python2-redis -y
+RUN git clone https://github.com/distributed-system-analysis/smallfile
+RUN mv smallfile smallfile-master
+COPY snafu /opt/snafu

--- a/sysbench/Dockerfile
+++ b/sysbench/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos/tools
+MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
+
+RUN yum install -y epel-release
+RUN yum install -y sysbench

--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos/tools
+
+USER root
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y yum-plugin-copr
+RUN yes | yum copr enable ndokos/pbench
+RUN yum install -y pbench-uperf
+RUN yum install -y redis
+RUN yum install -y git python-pip
+RUN pip install --upgrade pip
+RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
+RUN yum install -y numpy
+COPY snafu /opt/snafu

--- a/ycsb-wrapper/Dockerfile
+++ b/ycsb-wrapper/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:7
+
+USER root
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y java
+RUN curl -O --location https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz
+RUN mkdir ycsb
+RUN tar xzf ycsb-0.15.0.tar.gz -C ycsb --strip-components 1
+RUN yum install -y redis
+RUN yum install -y git python-pip
+RUN pip install --upgrade pip
+RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
+RUN yum install -y numpy
+COPY snafu /opt/snafu


### PR DESCRIPTION
This is due to the following reasons:
1. magazine can't exist on its own, as the user would need to understand how to trigger it
2. reduces overhead of having to update image in magazine when snafu is updated