### PR TITLE
Fs drift dockerfile

### DIFF
--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -1,8 +1,11 @@
 FROM centos/tools
-MAINTAINER Ben England <bengland@redhat.com>
-
+USER root
 RUN rpm -iv https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y git python-elasticsearch6 python-redis python2-numpy
+RUN yum install -y python2-pip
+RUN pip install --upgrade pip
+RUN pip install elasticsearch configparser statistics numpy scipy redis
+RUN mkdir -pv /opt/snafu
+COPY * /opt/snafu/
 RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift
-RUN mkdir -p /opt/snafu/
-COPY . /opt/snafu/
+RUN ln -sv /opt/fs-drift/fs-drift.py /usr/local/bin/
+RUN ln -sv /opt/fs-drift/rsptime_stats.py /usr/local/bin/

--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -y python2-pip
 RUN pip install --upgrade pip
 RUN pip install elasticsearch configparser statistics numpy scipy redis
 RUN mkdir -pv /opt/snafu
-COPY * /opt/snafu/
+COPY . /opt/snafu/
 RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift
 RUN ln -sv /opt/fs-drift/fs-drift.py /usr/local/bin/
 RUN ln -sv /opt/fs-drift/rsptime_stats.py /usr/local/bin/

--- a/fs_drift_wrapper/trigger_fs_drift.py
+++ b/fs_drift_wrapper/trigger_fs_drift.py
@@ -46,7 +46,7 @@ class _trigger_fs_drift:
         json_output_file = os.path.join(self.result_dir, 'fs-drift.json')
         network_shared_dir = os.path.join(self.working_dir, 'network-shared')
         rsptime_file = os.path.join(network_shared_dir, 'stats-rsptimes.csv')
-        cmd = ["python", "fs-drift.py", 
+        cmd = ["fs-drift.py", 
                 "--top", self.working_dir, 
                 "--output-json", json_output_file,
                 "--response-times", "Y",
@@ -74,7 +74,7 @@ class _trigger_fs_drift:
         elapsed_time = float(data['results']['elapsed'])
         start_time = data['results']['start-time']
         sampling_interval = max(int(elapsed_time/120.0), 1)
-        cmd = ["python", "rsptime_stats.py",
+        cmd = ["rsptime_stats.py",
                 "--time-interval", str(sampling_interval),
                 rsptime_dir ]
         self.logger.info("process response times with: %s" % ' '.join(cmd))


### PR DESCRIPTION
This has been tested in AWS cluster, previously I wasn't testing run_snafu.py from inside a container built with the Dockerfile.     Note that this depends on pip instead of RPM now and python scripts that are run by trigger are assumed to be in PATH (Dockerfile does this).