### PR TITLE
do not return intervals where no IOPS happened

### DIFF
--- a/fs_drift_wrapper/trigger_fs_drift.py
+++ b/fs_drift_wrapper/trigger_fs_drift.py
@@ -105,6 +105,13 @@ class _trigger_fs_drift:
                     interval['date'] = rsptime_date_str
                     # number of fs-drift file operations in this interval
                     interval['op-count'] = int(flds[2])
+                    if interval['op-count'] == 0:
+                        self.logger.info(
+                            'no response time data in interval starting at ' + rsptime_date_str)
+                        # no response time data for this interval
+                        # FIXME: how do we indicate to grafana that preceding sample
+                        # is not continuing into this interval.
+                        continue
                     # file operations per second in this interval
                     interval['file-ops-per-sec'] = float(flds[2]) / sampling_interval
                     interval['min'] = float(flds[3])


### PR DESCRIPTION
for time-series response-time data, it is possible to have an interval where zero IOPS happened, and in this case the response time results are UNDEFINED!   This resulted in a python exception before, but now we handle this by omitting the ES document for that interval at present (how does Grafana represent an omitted interval? TBD)