### PR TITLE
corrected the evaluation of start time

### DIFF
--- a/fio_wrapper/trigger_fio.py
+++ b/fio_wrapper/trigger_fio.py
@@ -57,7 +57,7 @@ class _trigger_fio:
                 document['global_options'] = fio_jobs_dict['global']
             processed.append(document)
             if result['jobname'] != 'All clients':
-                start_time= (int(end_time) * 1000) - result['job_runtime']
+                start_time= (int(end_time) * 1000)
                 fio_starttime[result['hostname']] = start_time
                 if start_time < earliest_starttime:
                     earliest_starttime = start_time


### PR DESCRIPTION
Following running a few fio sequential write test it was discovered that fio log data and system metrics captured via Prometheus were not aligned. After closer inspection it was determined that fio data was misaligned due to the evaluation of start_time. 

The specific correction removing the rolling back of time based on the "duration". 

The following link demonstrates the issue:
http://marquez.perf.lab.eng.rdu2.redhat.com:3000/d/-8bpuoNWk/fio-summary-with-rook-ceph?orgId=1&from=1570216136317&to=1570220826043&var-user=acalhoun&var-UUID=0761ec34-6e0a-573b-bd6f-c810602cdf48&var-cluster_name=acalhoun&var-Operation=All&var-io_size=All&var-log_interval=30s&var-net_device=All&var-block_device=All&var-instances=All


After the correction:
http://marquez.perf.lab.eng.rdu2.redhat.com:3000/d/-8bpuoNWk/fio-summary-with-rook-ceph?orgId=1&from=1570468848765&to=1570471964274&var-user=acalhoun&var-UUID=0761ec34-6e0a-573b-bd6f-c810602cdf48&var-cluster_name=acalhoun&var-Operation=All&var-io_size=All&var-log_interval=30s&var-net_device=All&var-block_device=All&var-instances=All

@aakarshg 