### PR TITLE
add optype field to response time documents

### DIFF
--- a/smallfile_wrapper/trigger_smallfile.py
+++ b/smallfile_wrapper/trigger_smallfile.py
@@ -115,6 +115,7 @@ class _trigger_smallfile:
                             interval['uuid'] = self.uuid
                             interval['user'] = self.user
                             interval['sample'] = self.sample
+                            interval['optype'] = operation
                             interval['host'] = self.host
                             interval['date'] = rsptime_date_str
                             interval['min'] = float(flds[3])


### PR DESCRIPTION
trivial change, but you need this plus sample to extract response time data for 1 smallfile run
verified that optype field shows up in ES