### PR TITLE
fix cache issues while building images

### DIFF
--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -6,6 +6,7 @@ RUN pip install --upgrade pip
 RUN pip install elasticsearch configparser statistics numpy scipy redis
 RUN mkdir -pv /opt/snafu
 COPY . /opt/snafu/
+ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift
 RUN ln -sv /opt/fs-drift/fs-drift.py /usr/local/bin/
 RUN ln -sv /opt/fs-drift/rsptime_stats.py /usr/local/bin/

--- a/smallfile_wrapper/Dockerfile
+++ b/smallfile_wrapper/Dockerfile
@@ -4,6 +4,7 @@ RUN yum install git epel-release -y
 RUN yum install python2-pip python2-numpy scipy python2-configparser python2-redis -y
 RUN pip install --upgrade pip
 RUN pip install elasticsearch statistics
+ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/distributed-system-analysis/smallfile
 RUN mv smallfile /opt/
 RUN ln -sv /opt/smallfile/smallfile_cli.py /usr/local/bin/


### PR DESCRIPTION
Container build process through quay.io uses caches images, so have to bust the cache,
this is done by using github api to check for update.

See https://github.com/moby/moby/issues/1996 for more details.