### PR TITLE
Smf statvfs

### DIFF
--- a/smallfile_wrapper/trigger_smallfile.py
+++ b/smallfile_wrapper/trigger_smallfile.py
@@ -7,6 +7,7 @@ import subprocess
 import logging
 import shutil
 import socket
+from vfs_stat import get_vfs_stat_dict
 
 class SmallfileWrapperException(Exception):
     pass
@@ -71,6 +72,9 @@ class _trigger_smallfile:
                         self.sample, operation, json_output_file))
             if operation == 'cleanup':
                 continue  # skip reporting data
+
+            fsdict = get_vfs_stat_dict(self.working_dir)
+
             with open(json_output_file) as f:
                 data = json.load(f)
                 timestamp = data['results']['date']
@@ -78,6 +82,7 @@ class _trigger_smallfile:
                 for tid in data['results']['in-thread'].keys():
                     thrd = data['results']['in-thread'][tid]
                     thrd['params'] = params
+                    thrd['fsinfo'] = fsdict
                     thrd['cluster_name'] = self.cluster_name
                     thrd['uuid'] = self.uuid
                     thrd['user'] = self.user

--- a/vfs_stat.py
+++ b/vfs_stat.py
@@ -1,0 +1,39 @@
+# module to calculate filesystem statistics from statvfs info
+# in a form suitable for inclusion in Elasticsearch documents
+
+import os
+import json
+import sys
+
+bytes_per_GiB = 1024.0 * 1024.0 * 1024.0
+
+def get_vfs_stat_dict(fspath):
+    vfsinfo = os.statvfs(fspath)
+    fsdict = {}
+    #fsdict['bsize'] = vfsinfo.f_bsize
+    #fsdict['frsize'] = vfsinfo.f_frsize
+    #fsdict['blocks'] = vfsinfo.f_blocks
+    #fsdict['bfree'] = vfsinfo.f_bfree
+    #fsdict['bavail'] = vfsinfo.f_bavail
+    #fsdict['files'] = vfsinfo.f_files
+    #fsdict['ffree'] = vfsinfo.f_ffree
+    #fsdict['favail'] = vfsinfo.f_favail
+    # note: bin only supported in python 3
+    #fsdict['flag'] = bin(vfsinfo.f_flag)
+    #fsdict['fsid'] = '0x%x' % vfsinfo.f_fsid
+    fsdict['vfs-stat-path'] = fspath
+    fsdict['GiB-blocks'] = vfsinfo.f_blocks * vfsinfo.f_bsize / bytes_per_GiB
+    # simulates "df" output
+    fsdict['pct-bytes-free'] = '%6.3f' % (100.0 * vfsinfo.f_bfree / vfsinfo.f_blocks)
+    # simulates "df -i" output
+    fsdict['pct-files-free'] = '%6.3f' % (100.0 * vfsinfo.f_ffree / vfsinfo.f_files)
+    return fsdict
+
+# unit test
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        dirpath = sys.argv[1]
+    else:
+        dirpath = '.'
+    print(json.dumps(get_vfs_stat_dict(dirpath), indent=4))


### PR DESCRIPTION
this PR includes a new top-level module that gathers filesystem statistics about any POSIX filesystem given a pathname.   The smallfile wrapper calls this to gather info about space and inodes used after a test completes.   This will be used by fs-drift also and could be used by other storage-related benchmarks.   For example, you can see whether the filesystem is filled up or near filled up after a test.