### PR TITLE
Adding CI testing

### DIFF
--- a/ci/check_es.py
+++ b/ci/check_es.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import argparse
+import elasticsearch
+import sys
+
+def _check_index(server,port,uuid,index):
+    _es_connection_string = str(server) + ':' + str(port)
+    es = elasticsearch.Elasticsearch([_es_connection_string],send_get_body_as='POST')
+    results = es.search(index=index, body={'query': {'term': {'uuid.keyword': uuid}}}, size=1)
+    if results['hits']['total']['value'] > 0:
+        return 0
+    else:
+        print("No result found in ES")
+        return 1
+
+def main():
+    parser = argparse.ArgumentParser(description="Script to verify uploads to ES")
+    parser.add_argument(
+        '-s', '--server',
+        help='Provide elastic server information')
+    parser.add_argument(
+        '-p', '--port',
+        help='Provide elastic port information')
+    parser.add_argument(
+        '-u', '--uuid',
+        help='UUID to provide to search')
+    parser.add_argument(
+        '-i', '--index',
+        help='Index to provide to search')
+    args = parser.parse_args()
+    
+    sys.exit(_check_index(args.server,args.port,args.uuid,args.index))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+es_server="marquez.perf.lab.eng.rdu2.redhat.com"
+es_port=9200
+
+function update_operator_image() {
+  tag_name=$1
+  operator-sdk build quay.io/rht_perf_ci/benchmark-operator:$tag_name --image-builder podman
+
+  # In case we have issues uploading to quay we will retry a few times
+  try_count=0
+  while [ $try_count -le 2 ]
+  do
+    if podman push quay.io/rht_perf_ci/benchmark-operator:$tag_name
+    then
+      try_count=2
+    elif [[ $try_count -eq 2 ]]
+    then
+      echo "Could not upload image to quay. Exiting"
+      exit 1
+    fi
+    ((try_count++))
+  done
+  sed -i "s|          image: quay.io/benchmark-operator/benchmark-operator:master*|          image: quay.io/rht_perf_ci/benchmark-operator:$tag_name # |" resources/operator.yaml
+}
+
+function wait_clean {
+  kubectl delete all --all -n my-ripsaw
+  for i in {1..30}; do
+    if [ `kubectl get pods --namespace my-ripsaw | wc -l` -ge 1 ]; then
+      sleep 5
+    else
+      break
+    fi
+  done
+}
+
+# Takes 2 arguements. $1 is the uuid and $2 is a space seperated list of indexs to check
+# Returns 0 if ALL indexes are found
+function check_es() {
+  uuid=$1
+  index=${@:2}
+
+  rc=0
+  for my_index in $index
+  do
+    python3 ci/check_es.py -s $es_server -p $es_port -u $uuid -i $my_index
+    ec=$?
+    if [[ $ec -ne 0 ]]
+    then
+      exit 1
+    fi
+  done
+  exit 0
+}
+
+# Takes test script as parameter and returns the uuid
+function get_uuid() {
+  my_test=$1
+  
+  sed -i '/trap finish EXIT/d' tests/$my_test
+
+  rm -f uuid
+  (
+  source tests/$my_test || :
+
+  # Get UUID
+  uuid=`kubectl -n my-ripsaw get benchmarks -o jsonpath='{.items[0].status.uuid}'`
+
+  finish
+  echo $uuid > uuid
+  )
+}

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -1,0 +1,66 @@
+#/bin/bash
+
+set -x
+
+source ci/common.sh
+
+wait_clean
+
+kubectl create namespace my-ripsaw
+
+# Clone ripsaw so we can use it for testing
+rm -rf ripsaw
+git clone https://github.com/cloud-bulldozer/ripsaw.git
+
+# Disable metadata collection to save time
+sed -i 's/metadata_collection: true/metadata_collection: false/g' ripsaw/tests/test_crs/*
+
+# Prep results.markdown file
+echo "Results for SNAFU CI Test" > results.markdown
+echo "" >> results.markdown
+echo 'Test | Result | Runtime' >> results.markdown
+echo '-----|--------|--------' >> results.markdown
+
+diff_list=`git diff master --name-only`
+
+# Run a full test if:
+# - anything in . has been changed (ie run_snafu.py)
+# - anything in ci has been changed
+# - anything in utils has been changed
+# Else only run tests on directories that have changed
+if [[ `echo $diff_list | grep -v / | wc -l` -gt 0 || `echo $diff_list | grep ci/` || `echo $diff_list | grep utils/` ]]
+then
+  echo "Running full test"
+  test_list=`ls -d */ | grep -v utils/ | grep -v ci/ | grep -v ripsaw/`
+else
+  echo "Running specific tests"
+  echo $diff_list
+  test_list=`echo $diff_list | awk -F "/" '{print $1}' | uniq`
+fi
+
+echo "Running tests in the following directories: "$test_list
+test_rc=0
+
+for dir in `echo $test_list`
+do
+  start_time=`date`
+  my_dir=${dir::-1}
+  figlet "CI test for "$my_dir
+  if $my_dir/ci_test.sh
+  then
+    end_time=`date`
+    duration=`date -ud@$(($(date -ud"$end_time" +%s)-$(date -ud"$start_time" +%s))) +%T`
+    echo ${dir::-1}" | PASS | "$duration >> results.markdown
+  else
+    end_time=`date`
+    duration=`date -ud@$(($(date -ud"$end_time" +%s)-$(date -ud"$start_time" +%s))) +%T`
+    echo ${dir::-1}" | FAIL | "$duration >> results.markdown
+    test_rc=1
+  fi
+  wait_clean
+done
+
+echo "Summary of CI Test"
+cat results.markdown
+
+exit $test_rc

--- a/fio_wrapper/ci_test.sh
+++ b/fio_wrapper/ci_test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/fio:snafu_ci -f fio_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/fio:snafu_ci
+
+cd ripsaw
+
+sed -i 's/fio:latest/fio:snafu_ci/g' roles/fio-distributed/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_fiod.sh
+uuid=`cat uuid`
+
+cd ..
+
+# Define index
+index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
+
+check_es $uuid $index
+exit $?

--- a/fs_drift_wrapper/ci_test.sh
+++ b/fs_drift_wrapper/ci_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/fs-drift:snafu_ci -f fs_drift_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/fs-drift:snafu_ci
+
+cd ripsaw
+
+sed -i 's/fs-drift:master/fs-drift:snafu_ci/g' roles/fs-drift/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_fs_drift.sh
+uuid=`cat uuid`
+
+cd ..
+
+index="ripsaw-fs-drift-results"
+
+check_es $uuid $index
+exit $?

--- a/hammerdb/ci_test.sh
+++ b/hammerdb/ci_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/hammerdb:snafu_ci -f hammerdb/Dockerfile . && podman push quay.io/cloud-bulldozer/hammerdb:snafu_ci
+
+cd ripsaw
+
+sed -i 's/hammerdb:latest/hammerdb:snafu_ci/g' roles/hammerdb/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_hammerdb.sh
+uuid=`cat uuid`
+
+cd ..
+
+index="ripsaw-hammerdb-results"
+
+check_es $uuid $index
+exit $?

--- a/iperf/ci_test.sh
+++ b/iperf/ci_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/iperf:snafu_ci -f iperf/Dockerfile . && podman push quay.io/cloud-bulldozer/iperf:snafu_ci
+
+cd ripsaw
+
+sed -i 's/iperf:latest/iperf:snafu_ci/g' roles/iperf3-bench/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+# iperf does not utilize a wrapper from snafu, only the Dockerfile
+# We will confirm that the test_iperf passes only
+bash tests/test_iperf3.sh 

--- a/pgbench-wrapper/ci_test.sh
+++ b/pgbench-wrapper/ci_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/pgbench:snafu_ci -f pgbench-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/pgbench:snafu_ci
+
+cd ripsaw
+
+sed -i 's/latest/snafu_ci/g' roles/pgbench/defaults/main.yml
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_pgbench.sh
+uuid=`cat uuid`
+
+cd ..
+
+index="ripsaw-pgbench-summary"
+
+check_es $uuid $index
+exit $?

--- a/smallfile_wrapper/ci_test.sh
+++ b/smallfile_wrapper/ci_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/smallfile:snafu_ci -f smallfile_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/smallfile:snafu_ci
+
+cd ripsaw
+
+sed -i 's/smallfile:master/smallfile:snafu_ci/g' roles/smallfile-bench/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_smallfile.sh
+uuid=`cat uuid`
+
+cd ..
+
+index="ripsaw-smallfile-results ripsaw-smallfile-rsptimes"
+
+check_es $uuid $index
+exit $?

--- a/sysbench/ci_test.sh
+++ b/sysbench/ci_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/sysbench:snafu_ci -f sysbench/Dockerfile . && podman push quay.io/cloud-bulldozer/sysbench:snafu_ci
+
+cd ripsaw
+
+sed -i 's/sysbench:latest/sysbench:snafu_ci/g' roles/sysbench/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+# sysbench does not utilize a wrapper from snafu, only the Dockerfile
+# We will confirm that the test_sysbench passes only
+bash tests/test_sysbench.sh 

--- a/uperf-wrapper/ci_test.sh
+++ b/uperf-wrapper/ci_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build uperf image for ci
+podman build --tag=quay.io/cloud-bulldozer/uperf:snafu_ci -f uperf-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/uperf:snafu_ci
+
+cd ripsaw
+
+sed -i 's/uperf:latest/uperf:snafu_ci/g' roles/uperf-bench/templates/*
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_uperf.sh
+uuid=`cat uuid`
+
+cd ..
+
+index="ripsaw-uperf-results"
+
+check_es $uuid $index
+exit $?

--- a/ycsb-wrapper/ci_test.sh
+++ b/ycsb-wrapper/ci_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+podman build --tag=quay.io/cloud-bulldozer/ycsb-server:snafu_ci -f ycsb-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/ycsb-server:snafu_ci
+
+cd ripsaw
+
+sed -i 's/ycsb-server:latest/ycsb-server:snafu_ci/g' roles/load-ycsb/tasks/main.yml
+
+# Build new ripsaw image
+update_operator_image snafu_ci
+
+get_uuid test_ycsb.sh
+uuid=`cat uuid`
+
+cd ..
+
+index="ripsaw-ycsb-summary"
+
+check_es $uuid $index
+exit $?


### PR DESCRIPTION
Adding CI testing for SNAFU.

Notes:
- The test tries to intelligently run tests based on whats changed. If anything in the root, ci, or utils directory it runs all the test otherwise just the tests in the directories that changed.
- The tests rely on ripsaw so if a test is broken there it will fail the ci here
- Currently hammerdb, smallfile and fs-drift require PR's to be completed in ripsaw for the tests here to Pass
- For tests that index to ES we run a check to see if data is there for the index and uuid.
- Some tests do not have a wrapper so we do a functionality test by simply executing the ripsaw ci test to ensure the image is functioning.