### PR TITLE
Allow other location account

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ And here is a simple example of a ci_test.sh (they all look very similar):
 source ci/common.sh
 default_image_spec="quay.io/cloud-bulldozer/your_wrapper:master"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/your_wrapper:$SNAFU_IMAGE_TAG
-build_wrapper_image $image_spec your_wrapper
+build_and_push your_wrapper/Dockerfile $image_spec 
 
 cd ripsaw
 sed -i "s#$default_image_spec#$image_spec#" roles/your_wrapper_in_ripsaw/templates/*

--- a/README.md
+++ b/README.md
@@ -138,3 +138,55 @@ has an "object-oriented" parser - the only inherited parameter is the --tool par
 run_snafu.py uses the tool parameter to determine which wrapper to invoke, and
 The remaining parameters are defined and parsed by the workload-specific wrapper.
 
+
+## how do I run my snafu wrapper in CI?
+
+add the ci_test.sh script to your wrapper directory - the SNAFU CI (Continuous Integration) test harness 
+will automatically find it and run it.   This assumes that your wrapper supports ripsaw, for now.
+At present, the CI does not test SNAFU on baremetal but this may be added in the future.
+
+every ci_test.sh script makes use of environment variables defined in ci/common.sh :
+
+* RIPSAW_CI_IMAGE_LOCATION - defaults to quay.io
+* RIPSAW_CI_IMAGE_ACCOUNT - defaults to rht_perf_ci
+* SNAFU_IMAGE_TAG (defaults to snafu_ci)
+* SNAFU_IMAGE_BUILDER (defaults to podman, can be set to docker)
+
+You, the wrapper developer, can override these variables to use any container image repository 
+supported by ripsaw (quay.io is at present the only location tested).  
+
+NOTE: at present, you need to force these images to be public images so that minikube can
+load them.    A better method is needed.
+
+In your CI script, ci_test.sh, you can make use of these 2 environment variables:
+
+* SNAFU_IMAGE_TAG (defaults to snafu_ci)
+* SNAFU_WRAPPER_IMAGE_PREFIX - just concatenation of location and account
+
+And here is a simple example of a ci_test.sh (they all look very similar):
+
+```
+#!/bin/bash
+source ci/common.sh
+default_image_spec="quay.io/cloud-bulldozer/your_wrapper:master"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/your_wrapper:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec your_wrapper
+
+cd ripsaw
+sed -i "s#$default_image_spec#$image_spec#" roles/your_wrapper_in_ripsaw/templates/*
+
+# Build new ripsaw image
+update_operator_image
+
+# run the ripsaw CI for your wrapper in tests/ and get resulting UUID
+get_uuid test_your_wrapper.sh
+uuid=`cat uuid`
+
+cd ..
+
+# Define index (there can be more than 1)
+index="ripsaw-your-wrapper-results"
+
+check_es $uuid $index
+exit $?
+```

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -89,6 +89,10 @@ function get_uuid() {
   # Get UUID
   uuid=`kubectl -n my-ripsaw get benchmarks -o jsonpath='{.items[0].status.uuid}'`
 
+  # while we're here, let's verify that right image location and account got used
+
+  kubectl -n my-ripsaw describe pods | grep -i pulled
+
   finish
   echo $uuid > uuid
   )

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -41,16 +41,6 @@ function update_operator_image() {
     resources/operator.yaml
 }
 
-function build_wrapper_image() {
-  image_spec=$1
-  wrapper_dir=$2
-  if [ "$image_builder" = "docker" ] ; then
-    docker build --tag=$image_spec -f $wrapper_dir/Dockerfile . && docker push $image_spec
-  elif [ "$image_builder" = "podman" ] ; then
-    $SUDO buildah bud --tag $image_spec -f $wrapper_dir/Dockerfile . && $SUDO podman push $image_spec
-  fi
-}
-
 function wait_clean {
   kubectl delete all --all -n my-ripsaw
   for i in {1..30}; do

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -2,26 +2,51 @@
 
 es_server="marquez.perf.lab.eng.rdu2.redhat.com"
 es_port=9200
+default_operator_image="quay.io/benchmark-operator/benchmark-operator:master"
+
+image_location=${RIPSAW_CI_IMAGE_LOCATION:-quay.io}
+image_account=${RIPSAW_CI_IMAGE_ACCOUNT:-rht_perf_ci}
+export SNAFU_IMAGE_TAG=${SNAFU_IMAGE_TAG:-snafu_ci}
+export SNAFU_WRAPPER_IMAGE_PREFIX="$image_location/$image_account"
+echo "posting container images to $image_location with account $image_account"
+export image_builder=${SNAFU_IMAGE_BUILDER:-podman}
+
+NOTOK=1
+
+# see kubernetes initialization on last line of this script
+# which will be the first thing the wrapper ci_test.sh does to it
 
 function update_operator_image() {
-  tag_name=$1
-  operator-sdk build quay.io/rht_perf_ci/benchmark-operator:$tag_name --image-builder podman
+  image_spec=$image_location/$image_account/benchmark-operator:$SNAFU_IMAGE_TAG
+  operator-sdk build $image_spec --image-builder $image_builder
 
   # In case we have issues uploading to quay we will retry a few times
   try_count=0
   while [ $try_count -le 2 ]
   do
-    if podman push quay.io/rht_perf_ci/benchmark-operator:$tag_name
+    if $image_builder push $image_spec
     then
       try_count=2
     elif [[ $try_count -eq 2 ]]
     then
-      echo "Could not upload image to quay. Exiting"
-      exit 1
+      echo "Could not upload image to $image_location. Exiting"
+      exit $NOTOK
     fi
     ((try_count++))
   done
-  sed -i "s|          image: quay.io/benchmark-operator/benchmark-operator:master*|          image: quay.io/rht_perf_ci/benchmark-operator:$tag_name # |" resources/operator.yaml
+  sed -i \
+    "s|          image: $default_operator_image|          image: $image_spec # |" \
+    resources/operator.yaml
+}
+
+function build_wrapper_image() {
+  image_spec=$1
+  wrapper_dir=$2
+  if [ "$image_builder" = "docker" ] ; then
+    docker build --tag=$image_spec -f $wrapper_dir/Dockerfile . && docker push $image_spec
+  elif [ "$image_builder" = "podman" ] ; then
+    buildah bud --tag $image_spec -f $wrapper_dir/Dockerfile . && podman push $image_spec
+  fi
 }
 
 function wait_clean {
@@ -33,9 +58,11 @@ function wait_clean {
       break
     fi
   done
+  kubectl delete namespace my-ripsaw
+  kubectl create namespace my-ripsaw || exit $NOTOK
 }
 
-# Takes 2 arguements. $1 is the uuid and $2 is a space seperated list of indexs to check
+# Takes 2 arguments. $1 is the uuid and $2 is a space-separated list of indexes to check
 # Returns 0 if ALL indexes are found
 function check_es() {
   uuid=$1
@@ -44,14 +71,9 @@ function check_es() {
   rc=0
   for my_index in $index
   do
-    python3 ci/check_es.py -s $es_server -p $es_port -u $uuid -i $my_index
-    ec=$?
-    if [[ $ec -ne 0 ]]
-    then
-      exit 1
-    fi
+    python3 ci/check_es.py -s $es_server -p $es_port -u $uuid -i $my_index \
+      || exit $NOTOK
   done
-  exit 0
 }
 
 # Takes test script as parameter and returns the uuid
@@ -71,3 +93,7 @@ function get_uuid() {
   echo $uuid > uuid
   )
 }
+
+# initialization of K8S for ripsaw
+
+wait_clean

--- a/fio_wrapper/ci_test.sh
+++ b/fio_wrapper/ci_test.sh
@@ -4,15 +4,15 @@ set -x
 
 source ci/common.sh
 
-# Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/fio:snafu_ci -f fio_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/fio:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/fio:latest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/fio:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec fio_wrapper
 
 cd ripsaw
 
-sed -i 's/fio:latest/fio:snafu_ci/g' roles/fio-distributed/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/fio-distributed/templates/*
 
-# Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_fiod.sh
 uuid=`cat uuid`
@@ -24,3 +24,4 @@ index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
 
 check_es $uuid $index
 exit $?
+

--- a/fs_drift_wrapper/ci_test.sh
+++ b/fs_drift_wrapper/ci_test.sh
@@ -11,7 +11,7 @@ build_wrapper_image $image_spec fs_drift_wrapper
 
 cd ripsaw
 
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/fs-drift/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/fs-drift/templates/* roles/fs-drift/tasks/*
 
 # Build new ripsaw image
 update_operator_image

--- a/fs_drift_wrapper/ci_test.sh
+++ b/fs_drift_wrapper/ci_test.sh
@@ -5,14 +5,16 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/fs-drift:snafu_ci -f fs_drift_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/fs-drift:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/fs-drift:master"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/fs-drift:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec fs_drift_wrapper
 
 cd ripsaw
 
-sed -i 's/fs-drift:master/fs-drift:snafu_ci/g' roles/fs-drift/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/fs-drift/templates/*
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_fs_drift.sh
 uuid=`cat uuid`

--- a/hammerdb/ci_test.sh
+++ b/hammerdb/ci_test.sh
@@ -5,14 +5,16 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/hammerdb:snafu_ci -f hammerdb/Dockerfile . && podman push quay.io/cloud-bulldozer/hammerdb:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/hammerdb:latest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/hammerdb:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec hammerdb
 
 cd ripsaw
 
-sed -i 's/hammerdb:latest/hammerdb:snafu_ci/g' roles/hammerdb/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/hammerdb/templates/*
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_hammerdb.sh
 uuid=`cat uuid`

--- a/iperf/ci_test.sh
+++ b/iperf/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/iperf:latest"
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/iperf3:latest"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/iperf:$SNAFU_IMAGE_TAG
 build_wrapper_image $image_spec iperf
 

--- a/iperf/ci_test.sh
+++ b/iperf/ci_test.sh
@@ -5,15 +5,18 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/iperf:snafu_ci -f iperf/Dockerfile . && podman push quay.io/cloud-bulldozer/iperf:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/iperf:latest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/iperf:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec iperf
 
 cd ripsaw
 
-sed -i 's/iperf:latest/iperf:snafu_ci/g' roles/iperf3-bench/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/iperf3-bench/templates/*
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 # iperf does not utilize a wrapper from snafu, only the Dockerfile
 # We will confirm that the test_iperf passes only
 bash tests/test_iperf3.sh 
+

--- a/pgbench-wrapper/ci_test.sh
+++ b/pgbench-wrapper/ci_test.sh
@@ -5,14 +5,18 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/pgbench:snafu_ci -f pgbench-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/pgbench:snafu_ci
+default_ripsaw_image="quay.io/cloud-bulldozer/pgbench"
+default_ripsaw_tag="latest"
+image=$SNAFU_WRAPPER_IMAGE_PREFIX/pgbench
+build_wrapper_image $image_spec pgbench-wrapper
 
 cd ripsaw
 
-sed -i 's/latest/snafu_ci/g' roles/pgbench/defaults/main.yml
+sed -i "s#$default_ripsaw_image#$image#" roles/pgbench/defaults/main.yml
+sed -i "s#$default_ripsaw_tag#$SNAFU_IMAGE_TAG#" roles/pgbench/defaults/main.yml
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_pgbench.sh
 uuid=`cat uuid`

--- a/smallfile_wrapper/ci_test.sh
+++ b/smallfile_wrapper/ci_test.sh
@@ -5,14 +5,16 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/smallfile:snafu_ci -f smallfile_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/smallfile:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/smallfile:master"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/smallfile:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec smallfile_wrapper
 
 cd ripsaw
 
-sed -i 's/smallfile:master/smallfile:snafu_ci/g' roles/smallfile-bench/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/smallfile-bench/templates/*
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_smallfile.sh
 uuid=`cat uuid`
@@ -23,3 +25,4 @@ index="ripsaw-smallfile-results ripsaw-smallfile-rsptimes"
 
 check_es $uuid $index
 exit $?
+

--- a/smallfile_wrapper/ci_test.sh
+++ b/smallfile_wrapper/ci_test.sh
@@ -11,7 +11,7 @@ build_wrapper_image $image_spec smallfile_wrapper
 
 cd ripsaw
 
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/smallfile-bench/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/smallfile-bench/templates/* roles/smallfile-bench/tasks/*
 
 # Build new ripsaw image
 update_operator_image

--- a/sysbench/ci_test.sh
+++ b/sysbench/ci_test.sh
@@ -5,14 +5,16 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/sysbench:snafu_ci -f sysbench/Dockerfile . && podman push quay.io/cloud-bulldozer/sysbench:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/sysbench:latest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/sysbench:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec sysbench
 
 cd ripsaw
 
-sed -i 's/sysbench:latest/sysbench:snafu_ci/g' roles/sysbench/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/sysbench/templates/*
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 # sysbench does not utilize a wrapper from snafu, only the Dockerfile
 # We will confirm that the test_sysbench passes only

--- a/uperf-wrapper/ci_test.sh
+++ b/uperf-wrapper/ci_test.sh
@@ -11,7 +11,7 @@ build_wrapper_image $image_spec uperf-wrapper
 
 cd ripsaw
 
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/uperf/templates/*
+sed -si "s#$default_ripsaw_image_spec#$image_spec#g" roles/uperf-bench/templates/*
 
 # Build new ripsaw image
 update_operator_image

--- a/uperf-wrapper/ci_test.sh
+++ b/uperf-wrapper/ci_test.sh
@@ -4,15 +4,17 @@ set -x
 
 source ci/common.sh
 
-# Build uperf image for ci
-podman build --tag=quay.io/cloud-bulldozer/uperf:snafu_ci -f uperf-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/uperf:snafu_ci
+# Build image for ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/uperf:latest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/uperf:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec uperf-wrapper
 
 cd ripsaw
 
-sed -i 's/uperf:latest/uperf:snafu_ci/g' roles/uperf-bench/templates/*
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/uperf/templates/*
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_uperf.sh
 uuid=`cat uuid`

--- a/ycsb-wrapper/ci_test.sh
+++ b/ycsb-wrapper/ci_test.sh
@@ -5,14 +5,16 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/ycsb-server:snafu_ci -f ycsb-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/ycsb-server:snafu_ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/ycsb-server:latest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/ycsb-server:$SNAFU_IMAGE_TAG
+build_wrapper_image $image_spec ycsb-wrapper
 
 cd ripsaw
 
-sed -i 's/ycsb-server:latest/ycsb-server:snafu_ci/g' roles/load-ycsb/tasks/main.yml
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/load-ycsb/tasks/main.yml
 
 # Build new ripsaw image
-update_operator_image snafu_ci
+update_operator_image
 
 get_uuid test_ycsb.sh
 uuid=`cat uuid`


### PR DESCRIPTION
Snafu CI was tested on my laptop running F31 and minikube 1.6.1.    I was able to use docker to run the CI (except for ycsb, not sure why yet), but was not able to use podman, but this may just be a problem on my laptop rather than in general.  Also updated README.md to describe how CI works and how to test CI for your wrapper.  Do not test this without ripsaw PR 260 (allows container image location and account to be overridden by user).     Should address some of Snafu issue 90 (lack of user documentation).