### PR TITLE
Python3 and ubi8 migration

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -31,7 +31,7 @@ diff_list=`git diff origin/master --name-only`
 if [[ `echo $diff_list | grep -v / | wc -l` -gt 0 || `echo $diff_list | grep ci/` || `echo $diff_list | grep utils/` ]]
 then
   echo "Running full test"
-  test_list=`ls -d */ | grep -v utils/ | grep -v ci/ | grep -v ripsaw/`
+  test_list=`ls -d */ | grep -Ev "(utils|ci|ripsaw|image_resources)/"`
 else
   echo "Running specific tests"
   echo $diff_list

--- a/cluster_loader/cluster_loader.py
+++ b/cluster_loader/cluster_loader.py
@@ -10,7 +10,7 @@ import argparse
 import configparser
 import logging
 
-import trigger_cluster_loader
+from cluster_loader import trigger_cluster_loader
 
 logger = logging.getLogger("snafu")
 

--- a/fio_wrapper/Dockerfile
+++ b/fio_wrapper/Dockerfile
@@ -1,12 +1,9 @@
-FROM centos/tools
+FROM ubi8:latest
 
-USER root
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y yum-plugin-copr
-RUN yes | yum copr enable ndokos/pbench
-RUN yum install -y pbench-fio
-RUN yum install -y git python-pip
-RUN pip install --upgrade pip
-RUN pip install elasticsearch numpy configparser statistics
-RUN mkdir -p /opt/snafu/
+RUN dnf copr enable ndokos/pbench -y
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install --nodocs -y pbench-fio --enablerepo=centos8-appstream
+RUN dnf install --nodocs -y git python3-pip python3-requests python3-numpy
+RUN pip3 install --upgrade-strategy=only-if-needed pyyaml "elasticsearch>=6.0.0,<=7.0.2"
+RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/

--- a/fio_wrapper/fio_wrapper.py
+++ b/fio_wrapper/fio_wrapper.py
@@ -18,10 +18,10 @@ import os
 import argparse
 import configparser
 import logging
-import urllib2
+import requests
 
-from fio_analyzer import Fio_Analyzer
-import trigger_fio
+from fio_wrapper.fio_analyzer import Fio_Analyzer
+from fio_wrapper import trigger_fio
 
 logger = logging.getLogger("snafu")
 
@@ -78,7 +78,7 @@ class fio_wrapper():
                 os.mkdir(sample_dir)
             if self.cache_drop_ip:
                 try:
-                    drop = urllib2.urlopen("http://{}:9432/drop_osd_caches".format(self.cache_drop_ip)).read()
+                    drop = requests.get("http://{}:9432/drop_osd_caches".format(self.cache_drop_ip)).text
                 except:
                     logger.error("Failed HTTP request to Ceph OSD cache drop pod {}".format(self.cache_drop_ip))
                 if "SUCCESS" in drop:

--- a/fio_wrapper/trigger_fio.py
+++ b/fio_wrapper/trigger_fio.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from copy import deepcopy
-from fio_hist_parser import compute_percentiles_from_logs
 import re
 import os
 import sys
@@ -13,6 +12,7 @@ import configparser
 import statistics
 import time
 import logging
+from fio_wrapper.fio_hist_parser import compute_percentiles_from_logs
 
 logger = logging.getLogger("snafu")
 

--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -1,12 +1,10 @@
-FROM centos/tools
-USER root
-RUN rpm -iv https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y python2-pip
-RUN pip install --upgrade pip
-RUN pip install elasticsearch configparser statistics numpy scipy redis
-RUN mkdir -pv /opt/snafu
+FROM ubi8:latest
+
+RUN dnf install --nodocs -y git python3-pip python3-numpy python3-requests python3-scipy
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis pyyaml
+RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
 ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache
-RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift
+RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift --depth 1
 RUN ln -sv /opt/fs-drift/fs-drift.py /usr/local/bin/
 RUN ln -sv /opt/fs-drift/rsptime_stats.py /usr/local/bin/

--- a/fs_drift_wrapper/fs_drift_wrapper.py
+++ b/fs_drift_wrapper/fs_drift_wrapper.py
@@ -10,7 +10,7 @@ import argparse
 import configparser
 import logging
 
-import trigger_fs_drift
+from fs_drift_wrapper import fs_drift_wrapper, trigger_fs_drift
 
 logger = logging.getLogger("snafu")
 

--- a/hammerdb/Dockerfile
+++ b/hammerdb/Dockerfile
@@ -1,33 +1,21 @@
-FROM centos/tools
+FROM ubi8:latest
 
 # install requirements
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y expect git wget tcl unixODBC-devel unixODBC python-pip
+RUN dnf install --nodocs -y tcl unixODBC python3-pip python3-requests
 
-RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
-RUN ACCEPT_EULA=Y yum -y install msodbcsql17
-RUN ACCEPT_EULA=Y yum -y install msodbcsql
-RUN yum remove -y unixODBC-utf16 unixODBC-utf16-devel && yum -y clean all
-RUN yum clean all -y 
-
-RUN pip install --upgrade pip
-RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
-
-RUN mkdir -p /opt/snafu
+RUN curl https://packages.microsoft.com/config/rhel/8/prod.repo -o /etc/yum.repos.d/mssql-release.repo
+COPY image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
+RUN ACCEPT_EULA=Y dnf -y install --nodocs msodbcsql17 --enablerepo=centos8
+RUN dnf clean all
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
 COPY . /opt/snafu
 
 # Download and install the hammer suite
-RUN wget 'https://downloads.sourceforge.net/project/hammerdb/HammerDB/HammerDB-3.2/HammerDB-3.2-Linux-x86-64-Install?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fhammerdb%2Ffiles%2FHammerDB%2FHammerDB-3.2%2FHammerDB-3.2-Linux-x86-64-Install%2Fdownload&ts=1564587940&use_mirror=autoselect' -O hammer_installer
+RUN curl -L 'https://downloads.sourceforge.net/project/hammerdb/HammerDB/HammerDB-3.2/HammerDB-3.2-Linux-x86-64-Install?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fhammerdb%2Ffiles%2FHammerDB%2FHammerDB-3.2%2FHammerDB-3.2-Linux-x86-64-Install%2Fdownload&ts=1564587940&use_mirror=autoselect' -o hammer_installer
 RUN mkdir /hammer
 RUN chmod 755 hammer_installer
 RUN ./hammer_installer --prefix /hammer --mode silent
-
 COPY hammerdb/uid_entrypoint /usr/local/bin/
-
 RUN chmod g+w /etc/passwd
 RUN chmod 755 /usr/local/bin/uid_entrypoint
 RUN /usr/local/bin/uid_entrypoint
-
-
-
-

--- a/hammerdb/hammerd_wrapper.py
+++ b/hammerdb/hammerd_wrapper.py
@@ -13,7 +13,7 @@ def _run_hammerdb():
     cmd = "cd /hammer; ./hammerdbcli auto /workload/tpcc-workload.tcl"
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     stdout,stderr = process.communicate()
-    return stdout.strip(), process.returncode
+    return stdout.strip().decode("utf-8"), process.returncode
 
 def _fake_run():
     with open("hammerdb.log", "r") as input:

--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,0 +1,5 @@
+[centos8-appstream]
+name=CentOS-8-Appstream
+baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
+enabled=0
+gpgcheck=0

--- a/image_resources/centos8.repo
+++ b/image_resources/centos8.repo
@@ -1,0 +1,5 @@
+[centos8]
+name=CentOS-8
+baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
+enabled=0
+gpgcheck=0

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -1,5 +1,4 @@
-FROM centos/tools
+FROM ubi8:latest
 
-USER root
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y iperf3
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install --nodocs -y iperf3 --enablerepo=centos8-appstream

--- a/pgbench-wrapper/Dockerfile
+++ b/pgbench-wrapper/Dockerfile
@@ -1,15 +1,11 @@
-FROM centos/tools
+FROM ubi8:latest
 
-USER root
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN yum -y update
-RUN yum install -y postgresql11
-RUN yum install -y redis
-RUN yum install -y git python-pip
-RUN pip install --upgrade pip
-RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
-RUN yum install -y numpy
+RUN dnf install -y --nodocs https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf install -y --nodocs python3-pip python3-numpy python3-requests postgresql11
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/smallfile_wrapper/Dockerfile
+++ b/smallfile_wrapper/Dockerfile
@@ -1,14 +1,11 @@
-FROM centos/tools
+FROM ubi8:latest
 
-RUN yum install git epel-release -y
-RUN yum install python2-pip python2-numpy scipy python2-configparser python2-redis -y
-RUN pip install --upgrade pip
-RUN pip install elasticsearch statistics
+RUN dnf install --nodocs -y git python3-pip python3-numpy python3-requests python3-scipy
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis pyyaml
+RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
-RUN git clone https://github.com/distributed-system-analysis/smallfile
-RUN mv smallfile /opt/
+RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile --depth 1
 RUN ln -sv /opt/smallfile/smallfile_cli.py /usr/local/bin/
 RUN ln -sv /opt/smallfile/smallfile_rsptimes_stats.py /usr/local/bin/
-RUN mkdir -pv /opt/snafu
 # assumption: docker build -f smallfile_wrapper/Dockerfile .
 COPY . /opt/snafu/

--- a/smallfile_wrapper/smallfile_wrapper.py
+++ b/smallfile_wrapper/smallfile_wrapper.py
@@ -10,7 +10,7 @@ import argparse
 import configparser
 import logging
 
-import trigger_smallfile
+from smallfile_wrapper import trigger_smallfile
 
 logger = logging.getLogger("snafu")
 

--- a/sysbench/Dockerfile
+++ b/sysbench/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos/tools
+FROM ubi8:latest
 MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
 
-RUN yum install -y epel-release
-RUN yum install -y sysbench
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf install -y --nodocs sysbench

--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -1,14 +1,10 @@
-FROM centos/tools
+FROM ubi8:latest
 
-USER root
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y yum-plugin-copr
-RUN yes | yum copr enable ndokos/pbench
-RUN yum install -y pbench-uperf
-RUN yum install -y redis
-RUN yum install -y git python-pip
-RUN pip install --upgrade pip
-RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
-RUN yum install -y numpy
+RUN dnf copr enable ndokos/pbench -y
+RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-numpy pbench-uperf
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/uperf-wrapper/uperf-wrapper.py
+++ b/uperf-wrapper/uperf-wrapper.py
@@ -71,12 +71,12 @@ def _run_uperf(workload):
     cmd = "uperf -v -a -x -i 1 -m {}".format(workload)
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     stdout,stderr = process.communicate()
-    return stdout.strip(), process.returncode
+    return stdout.strip().decode("utf-8"), process.returncode
 
 def _parse_stdout(stdout):
     # This will effectivly give us:
     # ripsaw-test-stream-udp-16384
-    config = re.findall(r"running profile:(.*) \.\.\.",stdout)
+    config = re.findall(r"running profile:(.*) \.\.\.", stdout)
     test = re.split("-",config[0])[0]
     protocol = re.split("-",config[0])[1]
     size = re.split("-",config[0])[2]
@@ -84,7 +84,7 @@ def _parse_stdout(stdout):
     # This will yeild us this structure :
     #     timestamp, number of bytes, number of operations
     # [('1559581000962.0330', '0', '0'), ('1559581001962.8459', '4697358336', '286704') ]
-    results = re.findall(r"timestamp_ms:(.*) name:Txn2 nr_bytes:(.*) nr_ops:(.*)",stdout)
+    results = re.findall(r"timestamp_ms:(.*) name:Txn2 nr_bytes:(.*) nr_ops:(.*)", stdout)
     return { "test": test, "protocol": protocol, "message_size": size, "num_threads": nthr, "results" : results }
 
 def _summarize_data(data):
@@ -209,17 +209,17 @@ def main():
 
     stdout = _run_uperf(args.workload[0])
     if stdout[1] == 1 :
-        print "UPerf failed to execute, trying one more time.."
+        print("UPerf failed to execute, trying one more time..")
         stdout = _run_uperf(args.workload[0])
         if stdout[1] == 1:
-            print "UPerf failed to execute a second time, stopping..."
+            print("UPerf failed to execute a second time, stopping...")
             exit(1)
     data = _parse_stdout(stdout[0])
     documents = _json_payload(data,args.run[0],uuid,user,hostnetwork,serviceip,remoteip,clientips,args.cluster_name,args.resourcetype[0],server_node,client_node)
     if server != "" :
         if len(documents) > 0 :
             _index_result("ripsaw-uperf-results",server,port,documents)
-    print stdout[0]
+    print(stdout[0])
     if len(documents) > 0 :
       _summarize_data(documents)
 


### PR DESCRIPTION

**Benchmarks:**

- [x] FIO
- [x] SmallFile
- [x] FS-drift
- [x] HammerDB
- [x] IPerf
- [x] Sysbench
- [x] Uperf
- [x] PGbench
- [ ] YCSB: The original project does support python3 yet

**Notes**
- As part of this work, the base image will be migrated to Centos8 which runs python3 by default.
- Due to the python3 migration, relative imports have been replaced by absolute. Ref PEP 404: https://www.python.org/dev/peps/pep-0404/#imports
- Urllib2 is no longer available in Python3 and has been replaced by requests
