### PR TITLE
Improve image build & push reliability

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -71,3 +71,18 @@ function get_uuid() {
   echo $uuid > uuid
   )
 }
+
+# Takes 2 argumentes. $1 is the Dockerfile path and $2 is the image name
+function build_and_push() {
+  if ! podman build --tag=${2} -f ${1} . ; then
+    echo "Image building error. Exiting"
+    exit 1
+  fi
+  for i in {1..3}; do
+    podman push ${2} && break
+    if [[ ${i} == 3 ]]; then
+      echo "Could not upload image to registry. Exiting"
+      exit 1
+    fi
+  done
+}

--- a/fio_wrapper/ci_test.sh
+++ b/fio_wrapper/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/fio:snafu_ci -f fio_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/fio:snafu_ci
+build_and_push fio_wrapper/Dockerfile quay.io/cloud-bulldozer/fio:snafu_ci
 
 cd ripsaw
 

--- a/fs_drift_wrapper/ci_test.sh
+++ b/fs_drift_wrapper/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/fs-drift:snafu_ci -f fs_drift_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/fs-drift:snafu_ci
+build_and_push fs_drift_wrapper/Dockerfile quay.io/cloud-bulldozer/fs-drift:snafu_ci
 
 cd ripsaw
 

--- a/hammerdb/ci_test.sh
+++ b/hammerdb/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/hammerdb:snafu_ci -f hammerdb/Dockerfile . && podman push quay.io/cloud-bulldozer/hammerdb:snafu_ci
+build_and_push hammerdb/Dockerfile quay.io/cloud-bulldozer/hammerdb:snafu_ci
 
 cd ripsaw
 

--- a/iperf/ci_test.sh
+++ b/iperf/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/iperf:snafu_ci -f iperf/Dockerfile . && podman push quay.io/cloud-bulldozer/iperf:snafu_ci
+build_and_push iperf/Dockerfile quay.io/cloud-bulldozer/iperf:snafu_ci
 
 cd ripsaw
 

--- a/pgbench-wrapper/ci_test.sh
+++ b/pgbench-wrapper/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/pgbench:snafu_ci -f pgbench-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/pgbench:snafu_ci
+build_and_push pgbench-wrapper/Dockerfile quay.io/cloud-bulldozer/pgbench:snafu_ci
 
 cd ripsaw
 

--- a/smallfile_wrapper/ci_test.sh
+++ b/smallfile_wrapper/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/smallfile:snafu_ci -f smallfile_wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/smallfile:snafu_ci
+build_and_push smallfile_wrapper/Dockerfile quay.io/cloud-bulldozer/smallfile:snafu_ci
 
 cd ripsaw
 

--- a/sysbench/ci_test.sh
+++ b/sysbench/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/sysbench:snafu_ci -f sysbench/Dockerfile . && podman push quay.io/cloud-bulldozer/sysbench:snafu_ci
+build_and_push sysbench/Dockerfile quay.io/cloud-bulldozer/sysbench:snafu_ci
 
 cd ripsaw
 

--- a/uperf-wrapper/ci_test.sh
+++ b/uperf-wrapper/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build uperf image for ci
-podman build --tag=quay.io/cloud-bulldozer/uperf:snafu_ci -f uperf-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/uperf:snafu_ci
+build_and_push uperf-wrapper/Dockerfile quay.io/cloud-bulldozer/uperf:snafu_ci
 
 cd ripsaw
 

--- a/ycsb-wrapper/ci_test.sh
+++ b/ycsb-wrapper/ci_test.sh
@@ -5,7 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-podman build --tag=quay.io/cloud-bulldozer/ycsb-server:snafu_ci -f ycsb-wrapper/Dockerfile . && podman push quay.io/cloud-bulldozer/ycsb-server:snafu_ci
+build_and_push ycsb-wrapper/Dockerfile quay.io/cloud-bulldozer/ycsb-server:snafu_ci
 
 cd ripsaw
 


### PR DESCRIPTION
One of the issues we had, is that on failed builds the CI system keeps going and pushes an old cached image.
The same happens for push operations.
The new function `build_and_push` takes care exiting on failed image builds & push. It also includes a 3 retries logic for the image push operation.
