### PR TITLE
Fixing ambiguous master error

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -21,7 +21,7 @@ echo "" >> results.markdown
 echo 'Test | Result | Runtime' >> results.markdown
 echo '-----|--------|--------' >> results.markdown
 
-diff_list=`git diff master --name-only`
+diff_list=`git diff origin/master --name-only`
 
 # Run a full test if:
 # - anything in . has been changed (ie run_snafu.py)


### PR DESCRIPTION
CI is getting the following error when doing a git diff. As a result it is always running against all the tests. This is to resolve it.

```
...
++ git diff master --name-only
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
...
```