### PR TITLE
fix bug trimming last char in test dir

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -43,7 +43,7 @@ test_rc=0
 
 for dir in `echo $test_list`
 do
-  my_dir=${dir::-1}
+  my_dir=${dir}
   if [ -f $my_dir/ci_test.sh ]; then
     start_time=`date`
     figlet "CI test for "$my_dir


### PR DESCRIPTION
Without this ci would fail on trying to run against the workload (-last char ) so for hammerdb it'd try to look into hammerd instead of hammerdb. 