### PR TITLE
dont use cache for building images

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -74,7 +74,7 @@ function get_uuid() {
 
 # Takes 2 argumentes. $1 is the Dockerfile path and $2 is the image name
 function build_and_push() {
-  if ! podman build --tag=${2} -f ${1} . ; then
+  if ! podman build --no-cache --tag=${2} -f ${1} . ; then
     echo "Image building error. Exiting"
     exit 1
   fi


### PR DESCRIPTION
This will help with certain ci errors while pushing as it'll not include any stale layers, will probably increase CI run time but if it makes sure that the image we push is the latest and we can have full confidence in it while testing, this shouldn't be a problem