### PR TITLE
Migrate ycsb to ubi8 & python3

### DIFF
--- a/ycsb-wrapper/Dockerfile
+++ b/ycsb-wrapper/Dockerfile
@@ -1,15 +1,9 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8:latest
 
-USER root
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y java
-RUN curl -O --location https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz
-RUN mkdir ycsb
-RUN tar xzf ycsb-0.15.0.tar.gz -C ycsb --strip-components 1
-RUN yum install -y redis
-RUN yum install -y git python-pip
-RUN pip install --upgrade pip
-RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
-RUN yum install -y numpy
-RUN mkdir -p /opt/snafu/
+RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xzf -
+RUN mv ycsb-0.15.0 ycsb
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf install -y git java python3 python2 python3-pip python3-numpy
+RUN pip3 install --upgrade-strategy=only-if-needed pyyaml "elasticsearch>=6.0.0,<=7.0.2"
+RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/

--- a/ycsb-wrapper/ycsb-wrapper.py
+++ b/ycsb-wrapper/ycsb-wrapper.py
@@ -24,13 +24,13 @@ def _index_result(index,server,port,payload):
     _es_connection_string = str(server) + ':' + str(port)
     es = elasticsearch.Elasticsearch([_es_connection_string],send_get_body_as='POST')
     for result in payload :
-        print result
+        print(result)
         es.index(index=index,body=result)
 
 def _run(cmd):
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout,stderr = process.communicate()
-    return [ stdout.strip(), stderr.strip(), process.returncode]
+    stdout, stderr = process.communicate()
+    return stdout.strip().decode("utf-8"), stderr.strip().decode("utf-8"), process.returncode
 
 def _json_payload(data,iteration,uuid,user,phase,workload,driver,recordcount,operationcount,clustername):
     processed = []
@@ -152,33 +152,34 @@ def main():
 
     if args.load :
         phase = "load"
-        cmd = "/ycsb/bin/ycsb {} {} -s -P /tmp/ycsb/{} {}".format(phase,
+        python = "/usr/bin/python2"
+        cmd = "{} /ycsb/bin/ycsb {} {} -s -P /tmp/ycsb/{} {}".format(python, phase,
                                                                         args.driver[0],
                                                                         args.workload[0],
                                                                         extra)
-        stdout = _run(cmd)
-        output = "{}\n{}".format(stdout[0],stdout[1])
+        stdout, stderr, rc = _run(cmd)
+        output = "{}\n{}".format(stdout, stderr)
     else:
         phase = "run"
-        cmd = "/ycsb/bin/ycsb {} {} -s -P /tmp/ycsb/{} {}".format(phase,
+        cmd = "{} /ycsb/bin/ycsb {} {} -s -P /tmp/ycsb/{} {}".format(python, phase,
                                                                         args.driver[0],
                                                                         args.workload[0],
                                                                         extra)
-        stdout = _run(cmd)
-        output = "{}\n{}".format(stdout[0],stdout[1])
+        stdout, stderr, rc = _run(cmd)
+        output = "{}\n{}".format(stdout, stderr)
 
-    if stdout[2] != 0 :
-        print "YCSB failed to execute"
+    if rc != 0 :
+        print("YCSB failed to execute:\n%s", stderr)
         exit(1)
-    if "Error inserting" in stdout[1] :
-        print "YCSB failed to load database... Drop previous YCSB database"
+    if "Error inserting" in stderr:
+        print("YCSB failed to load database... Drop previous YCSB database")
         exit(1)
 
     data = _parse_stdout(output)
-    print output
+    print(output)
     documents,summary = _json_payload(data,args.run[0],uuid,user,phase,workload,args.driver[0],recordcount,operationcount,args.cluster_name)
     if server != "" :
-        print "Attempting to index results..."
+        print("Attempting to index results...")
         if len(documents) > 0 :
             index = "ripsaw-ycsb-results"
             _index_result(index,server,port,documents)


### PR DESCRIPTION
Migrate ycsb to ubi8 & python3,
YCSB is not python3 ready yet so we execute it with python2.
Improved logging as well.