### PR TITLE
setting python var for ycsb

### DIFF
--- a/ycsb-wrapper/ycsb-wrapper.py
+++ b/ycsb-wrapper/ycsb-wrapper.py
@@ -149,10 +149,9 @@ def main():
     extra = ""
     if not args.extra is None:
         extra = args.extra[0]
-
+    python = "/usr/bin/python2"
     if args.load :
         phase = "load"
-        python = "/usr/bin/python2"
         cmd = "{} /ycsb/bin/ycsb {} {} -s -P /tmp/ycsb/{} {}".format(python, phase,
                                                                         args.driver[0],
                                                                         args.workload[0],


### PR DESCRIPTION
Fails otherwise with:
```
root@ip-172-31-59-125: ~/aakarsh/ripsaw # oc logs -f ycsb-bench-job-workloada-bb3100eb-65pxz
Traceback (most recent call last):
  File "/opt/snafu/ycsb-wrapper/ycsb-wrapper.py", line 191, in <module>
    sys.exit(main())
  File "/opt/snafu/ycsb-wrapper/ycsb-wrapper.py", line 164, in main
    cmd = "{} /ycsb/bin/ycsb {} {} -s -P /tmp/ycsb/{} {}".format(python, phase,
UnboundLocalError: local variable 'python' referenced before assignment
```