### PR TITLE
Verify number of arguments on check_es

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ uuid=`cat uuid`
 
 cd ..
 
-# Define index (there can be more than 1)
+# Define index (there can be more than 1 separated by whitespaces)
 index="ripsaw-your-wrapper-results"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?
 ```

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -57,12 +57,13 @@ function wait_clean {
 # Takes 2 arguments. $1 is the uuid and $2 is a space-separated list of indexes to check
 # Returns 0 if ALL indexes are found
 function check_es() {
+  if [[ ${#} != 2 ]]; then
+    echo "Wrong number of arguments: ${#}"
+    exit $NOTOK
+  fi
   uuid=$1
   index=${@:2}
-
-  rc=0
-  for my_index in $index
-  do
+  for my_index in $index; do
     python3 ci/check_es.py -s $es_server -p $es_port -u $uuid -i $my_index \
       || exit $NOTOK
   done

--- a/fio_wrapper/ci_test.sh
+++ b/fio_wrapper/ci_test.sh
@@ -23,6 +23,6 @@ cd ..
 # Define index
 index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?
 

--- a/fs_drift_wrapper/ci_test.sh
+++ b/fs_drift_wrapper/ci_test.sh
@@ -22,6 +22,5 @@ uuid=`cat uuid`
 cd ..
 
 indexes="ripsaw-fs-drift-results ripsaw-fs-drift-rsptimes ripsaw-fs-drift-rates-over-time"
-for i in $indexes ; do
-  check_es $uuid $i || exit 1
-done
+check_es "${uuid}" "${indexes}"
+exit $?

--- a/hammerdb/ci_test.sh
+++ b/hammerdb/ci_test.sh
@@ -23,5 +23,5 @@ cd ..
 
 index="ripsaw-hammerdb-results"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?

--- a/pgbench-wrapper/ci_test.sh
+++ b/pgbench-wrapper/ci_test.sh
@@ -25,5 +25,5 @@ cd ..
 
 index="ripsaw-pgbench-summary"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?

--- a/smallfile_wrapper/ci_test.sh
+++ b/smallfile_wrapper/ci_test.sh
@@ -23,6 +23,6 @@ cd ..
 
 index="ripsaw-smallfile-results ripsaw-smallfile-rsptimes"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?
 

--- a/uperf-wrapper/ci_test.sh
+++ b/uperf-wrapper/ci_test.sh
@@ -23,5 +23,5 @@ cd ..
 
 index="ripsaw-uperf-results"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?

--- a/ycsb-wrapper/ci_test.sh
+++ b/ycsb-wrapper/ci_test.sh
@@ -23,5 +23,5 @@ cd ..
 
 index="ripsaw-ycsb-summary"
 
-check_es $uuid $index
+check_es "${uuid}" "${index}"
 exit $?


### PR DESCRIPTION
If for any reason `get_uuid` doesn't return any uuid, `check_es` is called with an empty $uuid argument. Due to this behavior, the current implementation of the function can led to false positives during CI tests.
This simple code improvement avoids this.
#111 