### PR TITLE
Add a way for ripsaw to query redis the uperf-test status code

### DIFF
--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf copr enable ndokos/pbench -y
 RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-numpy pbench-uperf
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml redis
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/uperf-wrapper/redis_utils.py
+++ b/uperf-wrapper/redis_utils.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+
+import redis
+
+class RedisUtils:
+    def __init__(self, redis_host, redis_port):
+        self.redis_host = redis_host
+        self.redis_port = redis_port
+        self.redis_cache = redis.Redis(host=self.redis_host, port=self.redis_port)
+
+    def set_code(self, test_name, test_args, test_status_code,):
+        self.redis_cache.hset(test_name, test_args, test_status_code)


### PR DESCRIPTION
@jtaleric @aakarshg  
With this commit the snafu-uperf will be able to send 3 params to redis (hash_name, test_name and status_code). With this information ripsaw-uperf can not only query to check if there is a failure but it can also identify **which** test/s failed. This can be used to only retry the failed test/s instead of starting from the beginning.  

```The example output shows uperf-test with 2 sets of parameters
10.131.0.143:6379> hget uperf-test uperf-stream-tcp-16384-1
"0"   #Completed
10.131.0.143:6379> hget uperf-test uperf-stream-tcp-16384-8
"1"   #Failed 
10.131.0.143:6379> hgetall uperf-test
1) "uperf-stream-tcp-16384-8"
2) "1"
3) "uperf-stream-tcp-16384-1"
4) "0"
10.131.0.143:6379>
```
This commit also adds the ability to echo the test which failed for better readability 
```
UPerf failed to execute with args uperf-stream-tcp-16384-8, trying one more time..  #from snafu
UPerf failed to execute with args uperf-stream-tcp-16384-8 second time, stopping.. #from snafu
Workload failed with argument stream-tcp-16384-8                    #from ripsaw   
```