### PR TITLE
Re-enabling metadata collection

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -12,9 +12,6 @@ kubectl create namespace my-ripsaw
 rm -rf ripsaw
 git clone https://github.com/cloud-bulldozer/ripsaw.git
 
-# Disable metadata collection to save time
-sed -i 's/metadata_collection: true/metadata_collection: false/g' ripsaw/tests/test_crs/*
-
 # Prep results.markdown file
 echo "Results for SNAFU CI Test" > results.markdown
 echo "" >> results.markdown


### PR DESCRIPTION
Metadata collection was previously disabled. However, since the ripsaw test waits for it to complete anyway we are waiting longer for the timeout than if the collection was actually done.