### PR TITLE
Converting datetime objects to str when dumping

### DIFF
--- a/run_snafu.py
+++ b/run_snafu.py
@@ -123,7 +123,7 @@ def process_generator(index_args, parser):
                                      "_source": action,
                                      "_id": ""}
                 es_valid_document["_id"] = hashlib.md5(str(action).encode()).hexdigest()
-                logger.debug(json.dumps(es_valid_document, indent=4))
+                logger.debug(json.dumps(es_valid_document, indent=4, default=str))
                 yield es_valid_document
 
 

--- a/utils/py_es_bulk.py
+++ b/utils/py_es_bulk.py
@@ -183,7 +183,7 @@ def streaming_bulk(es, actions):
                     "retry_count": retry_count,
                     "timestamp": _tstos(time.time())
                 }
-                jsonstr = json.dumps(doc, indent=4, sort_keys=True)
+                jsonstr = json.dumps(doc, indent=4, sort_keys=True,default=str)
                 print(jsonstr)
                 # errorsfp.flush()
                 failures += 1


### PR DESCRIPTION
Have been noticing issues when trying to do a json dump or process
json documents with datetime objects present.. example would be
uperf_ts, and this help avoid the issue by defaulting conversion
to str.