### PR TITLE
Add debugging tools

### DIFF
--- a/fio_wrapper/Dockerfile
+++ b/fio_wrapper/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
+RUN dnf install --nodocs -y python3-dnf-plugins-core
 RUN dnf copr enable ndokos/pbench -y
-COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install --nodocs -y pbench-fio --enablerepo=centos8-appstream
-RUN dnf install --nodocs -y git python3-pip python3-requests python3-numpy
-RUN pip3 install --upgrade-strategy=only-if-needed pyyaml "elasticsearch>=6.0.0,<=7.0.2"
+RUN dnf install --nodocs -y pbench-fio tcpdump git python3-pip python3-requests python3-numpy python3-pyyaml
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/

--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
-RUN dnf install --nodocs -y git python3-pip python3-numpy python3-requests python3-scipy
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis pyyaml
+RUN dnf install --nodocs -y tcpdump git python3-pip python3-numpy python3-requests python3-scipy python3-pyyaml
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
 ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache

--- a/hammerdb/Dockerfile
+++ b/hammerdb/Dockerfile
@@ -1,13 +1,11 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
 # install requirements
-RUN dnf install --nodocs -y tcl unixODBC python3-pip python3-requests 
+RUN dnf install --nodocs -y tcl unixODBC python3-pip python3-requests python3-pyyaml tcpdump
 
 RUN curl https://packages.microsoft.com/config/rhel/8/prod.repo -o /etc/yum.repos.d/mssql-release.repo
-COPY image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
-RUN ACCEPT_EULA=Y dnf -y install --nodocs msodbcsql17 --enablerepo=centos8
-RUN dnf clean all
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN ACCEPT_EULA=Y dnf -y install --nodocs msodbcsql17
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2"
 COPY . /opt/snafu
 RUN ln -s /usr/bin/python3 /usr/bin/python
 

--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,5 +1,0 @@
-[centos8-appstream]
-name=CentOS-8-Appstream
-baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
-enabled=0
-gpgcheck=0

--- a/image_resources/centos8.repo
+++ b/image_resources/centos8.repo
@@ -1,5 +1,0 @@
-[centos8]
-name=CentOS-8
-baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
-enabled=0
-gpgcheck=0

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -1,4 +1,3 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
-COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install --nodocs -y iperf3 --enablerepo=centos8-appstream
+RUN dnf install --nodocs -y iperf3

--- a/pgbench-wrapper/Dockerfile
+++ b/pgbench-wrapper/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubi8:latest
+FROM docker.io/centos:8
 
+RUN dnf install --nodocs -y python3-dnf-plugins-core
+RUN dnf module disable postgresql -y
 RUN dnf install -y --nodocs https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN dnf install -y --nodocs python3-pip python3-numpy python3-requests postgresql11
-COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN dnf install -y --nodocs python3-pip python3-numpy python3-requests python3-pyyaml postgresql11 redis tcpdump
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
 RUN mkdir -p /opt/snafu/

--- a/smallfile_wrapper/Dockerfile
+++ b/smallfile_wrapper/Dockerfile
@@ -1,11 +1,10 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
-RUN dnf install --nodocs -y git python3-pip python3-numpy python3-requests python3-scipy
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis pyyaml
+RUN dnf install --nodocs -y git python3-pip python3-numpy python3-requests python3-scipy python3-pyyaml tcpdump
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile --depth 1
 RUN ln -sv /opt/smallfile/smallfile_cli.py /usr/local/bin/
 RUN ln -sv /opt/smallfile/smallfile_rsptimes_stats.py /usr/local/bin/
-# assumption: docker build -f smallfile_wrapper/Dockerfile .
 COPY . /opt/snafu/

--- a/sysbench/Dockerfile
+++ b/sysbench/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm

--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -1,10 +1,9 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
+RUN dnf install --nodocs -y python3-dnf-plugins-core
 RUN dnf copr enable ndokos/pbench -y
-RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-numpy pbench-uperf
-COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-numpy python3-pyyaml pbench-uperf redis
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/ycsb-wrapper/Dockerfile
+++ b/ycsb-wrapper/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM docker.io/centos:8
 
 RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xzf -
 RUN mv ycsb-0.15.0 ycsb
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y git java python3 python2 python3-pip python3-numpy
-RUN pip3 install --upgrade-strategy=only-if-needed pyyaml "elasticsearch>=6.0.0,<=7.0.2"
+RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf install -y --nodocs git java python3 python2 python3-pip python3-numpy python3-pyyaml tcpdump
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/


### PR DESCRIPTION
We're currently using several packages from Centos8 repositories, so the best idea would be to start using Centos8 rather than ubi8 to simplify Dockerfiles and avoid using external repositories on ubi8 which might break the containers.

Container size does not differs very much from ubi8 based builds as shown in the example below:
```
$ podman images quay.io/cloud-bulldozer/uperf
REPOSITORY                      TAG      IMAGE ID       CREATED        SIZE
quay.io/cloud-bulldozer/uperf   latest   98211d2aa3fa   18 hours ago   474 MB
$ podman images quay.io/rsevilla/uperf
REPOSITORY               TAG       IMAGE ID       CREATED          SIZE
quay.io/rsevilla/uperf   centos8   82f8f7190fef   53 minutes ago   494 MB
```
In addition Centos8 ships iputils, iproute and other useful and debugging tools by default, so that would explain the extra size of the containers.