### PR TITLE
Add missing es indices to tests for ycsb/pgbench

### DIFF
--- a/pgbench-wrapper/ci_test.sh
+++ b/pgbench-wrapper/ci_test.sh
@@ -23,7 +23,7 @@ uuid=`cat uuid`
 
 cd ..
 
-index="ripsaw-pgbench-summary"
+index="ripsaw-pgbench-summary ripsaw-pgbench-raw"
 
 check_es "${uuid}" "${index}"
 exit $?

--- a/ycsb-wrapper/ci_test.sh
+++ b/ycsb-wrapper/ci_test.sh
@@ -21,7 +21,7 @@ uuid=`cat uuid`
 
 cd ..
 
-index="ripsaw-ycsb-summary"
+index="ripsaw-ycsb-summary ripsaw-ycsb-results"
 
 check_es "${uuid}" "${index}"
 exit $?


### PR DESCRIPTION
This will increase code coverage for ycsb and pgbench.