### PR TITLE
Fixing ci tests

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -36,6 +36,7 @@ function update_operator_image() {
 }
 
 function wait_clean {
+  kubectl delete benchmark --all -n my-ripsaw
   kubectl delete all --all -n my-ripsaw
   for i in {1..30}; do
     if [ `kubectl get pods --namespace my-ripsaw | wc -l` -ge 1 ]; then
@@ -44,8 +45,9 @@ function wait_clean {
       break
     fi
   done
-  kubectl delete namespace my-ripsaw
-  kubectl create namespace my-ripsaw || exit $NOTOK
+  if [[ `kubectl get namespace my-ripsaw` ]]; then
+    kubectl delete namespace my-ripsaw --wait=true
+  fi
 }
 
 # Takes 2 arguments. $1 is the uuid and $2 is a space-separated list of indexes to check
@@ -99,5 +101,3 @@ function build_and_push() {
     fi
   done
 }
-
-wait_clean

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -4,10 +4,6 @@ set -x
 
 source ci/common.sh
 
-wait_clean
-
-kubectl create namespace my-ripsaw
-
 # Clone ripsaw so we can use it for testing
 rm -rf ripsaw
 git clone https://github.com/cloud-bulldozer/ripsaw.git --depth 1
@@ -48,6 +44,8 @@ fi
 
 echo -e "Running tests in the following directories:\n${test_list}"
 test_rc=0
+
+wait_clean
 
 for dir in ${test_list}; do
   start_time=`date`


### PR DESCRIPTION
This is to fix https://github.com/cloud-bulldozer/snafu/issues/152 as well as clean up a few of the ci bits.

My reasoning is similar to what we dealt with in ripsaw where the namespace was trying to be deleted multiple times and one of those failures from the wait_clean in run_ci.sh was returning an error because the namespaces was not there to be deleted. This then caused it to stop after the first test. I added in the same logic to this wait_clean as the ripsaw one where we check if it exists first. Additionally, I cleaned up some of the ordering and removed an unneeded wait_clean call.