### PR TITLE
Clean out minikube's images prior to testing

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -17,6 +17,8 @@ if [[ $ghprbPullLongDescription = *"Depends-On:"* ]]; then
   cd ..
 fi
 
+# Clean out minikube docker cache
+minikube ssh "docker image prune -af"
 
 # Prep results.markdown file
 cat > results.markdown << EOF


### PR DESCRIPTION
Minikube has been constantly filling its disk because of all the images it is storing in docker. This change adds a docker image prune to the run_ci.sh script to make sure we have enough space.