### PR TITLE
Install python libraries through requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ You must supply a "wrapper", which provides these functions:
 * build the container image for your benchmark, with all the packages, python modules, etc. that are required to run it.
 * runs the benchmark and stores the benchmark-specific results to an elasticsearch server
 
+Note: snafu is a python library, so please add the new python libraries you import
+to the requirements.txt
+
 Your ripsaw benchmark will define several environment variables relevant to Elasticsearch:
 * es - hostname of elasticsearch server
 * es_port - port number of elasticsearch server (default 9020)

--- a/fio_wrapper/Dockerfile
+++ b/fio_wrapper/Dockerfile
@@ -5,6 +5,6 @@ COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.r
 RUN dnf install -y --nodocs pbench-fio --enablerepo=centos8-appstream
 RUN dnf install -y --nodocs git python3-pip python3-requests python3-numpy
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN pip3 install --upgrade-strategy=only-if-needed pyyaml "elasticsearch>=6.0.0,<=7.0.2"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/fs_drift_wrapper/Dockerfile
+++ b/fs_drift_wrapper/Dockerfile
@@ -2,10 +2,10 @@ FROM registry.access.redhat.com/ubi8:latest
 
 RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-scipy
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis pyyaml
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
 ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift --depth 1
 RUN ln -sv /opt/fs-drift/fs-drift.py /usr/local/bin/
 RUN ln -sv /opt/fs-drift/rsptime_stats.py /usr/local/bin/
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/hammerdb/Dockerfile
+++ b/hammerdb/Dockerfile
@@ -8,7 +8,6 @@ RUN curl https://packages.microsoft.com/config/rhel/8/prod.repo -o /etc/yum.repo
 COPY image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 RUN ACCEPT_EULA=Y dnf -y install --nodocs msodbcsql17 --enablerepo=centos8
 RUN dnf clean all
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
 COPY . /opt/snafu
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
@@ -21,3 +20,4 @@ COPY hammerdb/uid_entrypoint /usr/local/bin/
 RUN chmod g+w /etc/passwd
 RUN chmod 755 /usr/local/bin/uid_entrypoint
 RUN /usr/local/bin/uid_entrypoint
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/pgbench-wrapper/Dockerfile
+++ b/pgbench-wrapper/Dockerfile
@@ -5,8 +5,8 @@ RUN dnf install -y --nodocs python3-pip python3-numpy python3-requests postgresq
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 configparser
-elasticsearch
+elasticsearch>=6.0.0,<=7.0.2
 statistics
 numpy
 pyyaml
+requests
+redis

--- a/smallfile_wrapper/Dockerfile
+++ b/smallfile_wrapper/Dockerfile
@@ -2,7 +2,6 @@ FROM registry.access.redhat.com/ubi8:latest
 
 RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-scipy
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" redis pyyaml
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile --depth 1
@@ -10,3 +9,4 @@ RUN ln -sv /opt/smallfile/smallfile_cli.py /usr/local/bin/
 RUN ln -sv /opt/smallfile/smallfile_rsptimes_stats.py /usr/local/bin/
 # assumption: docker build -f smallfile_wrapper/Dockerfile .
 COPY . /opt/snafu/
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests pytho
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/ycsb-wrapper/Dockerfile
+++ b/ycsb-wrapper/Dockerfile
@@ -5,6 +5,6 @@ RUN mv ycsb-0.15.0 ycsb
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf install -y --nodocs git java python3 python2 python3-pip python3-numpy
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN pip3 install --upgrade-strategy=only-if-needed pyyaml "elasticsearch>=6.0.0,<=7.0.2"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt


### PR DESCRIPTION
This will help push snafu to become a python library, and also
as we try to migrate other benchmarks to run_snafu and because of
imports each Dockerfile for the benchmark would be requiring more
libaries that aren't tracked in requirements.txt