### PR TITLE
Adding podman prune to ensure we don't fill local disk again

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -20,6 +20,9 @@ fi
 # Clean out minikube docker cache
 minikube ssh "docker image prune -af"
 
+# Podman image prune
+podman image prune -a
+
 # Prep results.markdown file
 cat > results.markdown << EOF
 Results for SNAFU CI Test


### PR DESCRIPTION
We were cleaning out the docker image cache but not the local podman cache. This change adds that to ensure we don't fill up the local filesystem again.