### PR TITLE
Fixing full test trigger to properly handle file changes in the root dir

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -35,7 +35,8 @@ diff_list=`git diff origin/master --name-only`
 # - anything in ci has been changed
 # - anything in utils has been changed
 # Else only run tests on directories that have changed
-if [[ `echo ${diff_list} | grep -cv /` -gt 0 || `echo ${diff_list} | grep -E "(ci|utils|image_resources)/"` ]]; then
+
+if [[ `echo "${diff_list}" | grep -cv /` -gt 0 || `echo ${diff_list} | grep -E "(ci|utils|image_resources)/"` ]]; then
   echo "Running full test"
   test_list=`find * -maxdepth 1 -name ci_test.sh -type f -exec dirname {} \;`
 else


### PR DESCRIPTION
Previously the full test trigger was not being properly executed if a file was changed in the root of the snafu directory. This fixes that.