### PR TITLE
Calculate redis timeout from last operation duration

### DIFF
--- a/smallfile_wrapper/smallfile_wrapper.py
+++ b/smallfile_wrapper/smallfile_wrapper.py
@@ -57,6 +57,7 @@ class smallfile_wrapper():
 
         self.redis_host = os.environ["redis_host"] if "redis_host" in os.environ else None
         self.redis_timeout = os.environ["redis_timeout"] if "redis_timeout" in os.environ else 60
+        self.redis_timeout_th = os.environ["redis_timeout_th"] if "redis_timeout_th" in os.environ else 25
         self.clients = os.environ["clients"] if "clients" in os.environ else 1
         if not self.args.top:
             raise SnafuSmfException('must supply directory where you access flies')  # noqa
@@ -81,6 +82,7 @@ class smallfile_wrapper():
                                                                      self.uuid,
                                                                      self.redis_host,
                                                                      self.redis_timeout,
+                                                                     self.redis_timeout_th,
                                                                      self.clients,
                                                                      s)
             yield trigger_generator


### PR DESCRIPTION
With the code included within this PR, redis synchronization socket timeout is smartly calculated taking into account the latest sample duration.
By default it adds an extra 25% of the duration of the latest sample. This parameter is configurable via env var so once we have it merged we should expose it to ripsaw.

Fixes #159 