### PR TITLE
Building uperf from src

### DIFF
--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -1,9 +1,17 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM registry.access.redhat.com/ubi8:latest as builder
 
-RUN dnf copr enable ndokos/pbench -y
-RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-numpy pbench-uperf
+RUN dnf install -y --nodocs git autoconf automake gcc make
+COPY image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
+RUN dnf install -y --enablerepo=centos8 lksctp-tools-devel
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN git clone https://github.com/uperf/uperf /tmp/uperf
+RUN pushd /tmp/uperf && autoreconf --install &&  ./configure --enable-cpc --enable-debug;make
+
+FROM registry.access.redhat.com/ubi8:latest
+COPY --from=builder /tmp/uperf/src/uperf /usr/local/bin/uperf
+RUN dnf install -y --nodocs python3-pip python3-numpy python3-requests python3-numpy
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
+RUN dnf install -y --nodocs redis lksctp-tools --enablerepo=centos8-appstream
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/

--- a/uperf-wrapper/uperf-wrapper.py
+++ b/uperf-wrapper/uperf-wrapper.py
@@ -72,7 +72,7 @@ def _json_payload(data, iteration, uuid, user, hostnetwork, serviceip, remote, c
 
 
 def _run_uperf(workload):
-    cmd = "uperf -v -a -x -i 1 -m {}".format(workload)
+    cmd = "uperf -v -a -X -i 1 -m {}".format(workload)
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()
     return stdout.strip().decode("utf-8"), process.returncode


### PR DESCRIPTION
Moving away from relying on pbench rpms for uperf, given that the
rpm support will soon be going away. This would mean that we've
to pull uperf's sourcecode compile it and use it. Uperf has a
single release so we can't try to use releases, and also uperf
only has the master branch so we'll have to rely on master branch.

Depends-On: 309