### PR TITLE
Use parallel ES indexing

### DIFF
--- a/run_snafu.py
+++ b/run_snafu.py
@@ -65,6 +65,7 @@ def main():
         if os.environ["es_port"] != "":
             es['port'] = os.environ["es_port"]
             logger.info("Using elasticsearch server with port:" + es['port'])
+        parallel = int(os.getenv('parallel_indexing', 0))
     es_verify_cert = os.getenv("es_verify_cert", "true")
     if len(es.keys()) == 2:
         if os.environ["es_index"] != "":
@@ -96,7 +97,8 @@ def main():
         res_beg, res_end, res_suc, res_dup, res_fail, res_retry = streaming_bulk(es,
                                                                                  process_generator(
                                                                                      index_args,
-                                                                                     parser))
+                                                                                     parser),
+                                                                                 parallel)
 
         logger.info(
             "Indexed results - %s success, %s duplicates, %s failures, with %s retries." % (


### PR DESCRIPTION
In a simple 10 minutes test I got:

```
2020-05-26T15:24:29Z - INFO     - MainProcess - trigger_fio: fio has successfully finished sample 1 executing for jobname write and results are in the dir /tmp/fiod-6c4f84f7-b18d-5c45-b2f8-b251633c7612/fiojob-write-4KiB-1/1/write
2020-05-26T15:26:19Z - INFO     - MainProcess - run_snafu: Indexed results - 27466 success, 0 duplicates, 0 failures, with 0 retries.
```

and with parallel
```
2020-05-26T15:09:48Z - INFO     - MainProcess - trigger_fio: fio has successfully finished sample 1 executing for jobname write and results are in the dir /tmp/fiod-6c4f84f7-b18d-5c45-b2f8-b251633c7612/fiojob-write-4KiB-1/1/write
2020-05-26T15:10:25Z - INFO     - MainProcess - run_snafu: Indexed results - 27458 success, 0 duplicates, 0 failures, with 0 retries.
```