### PR TITLE
Avoid rebuilding operator and checking ES twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.pydevproject
 *.pyc
 .tox/
+ripsaw
+results.markdown

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -7,6 +7,9 @@ source ci/common.sh
 # Clone ripsaw so we can use it for testing
 rm -rf ripsaw
 git clone https://github.com/cloud-bulldozer/ripsaw.git --depth 1
+pushd ripsaw
+update_operator_image
+popd
 
 # Generate uuid
 UUID=$(uuidgen)

--- a/src/fio_wrapper/ci_test.sh
+++ b/src/fio_wrapper/ci_test.sh
@@ -5,24 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/fio:latest"
-image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/fio:$SNAFU_IMAGE_TAG
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/fio:$SNAFU_IMAGE_TAG 
 build_and_push src/fio_wrapper/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/fio_distributed/templates/*
-
-update_operator_image
-
-get_uuid test_fiod.sh
-uuid=`cat uuid`
-
-cd ..
-
-# Define index
-index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
-
-check_es "${uuid}" "${index}"
-exit $?
-
+pushd ripsaw
+source tests/test_fiod.sh

--- a/src/fs_drift_wrapper/ci_test.sh
+++ b/src/fs_drift_wrapper/ci_test.sh
@@ -5,22 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/fs-drift:master"
-image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/fs-drift:$SNAFU_IMAGE_TAG
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/fs-drift:$SNAFU_IMAGE_TAG 
 build_and_push src/fs_drift_wrapper/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/fs-drift/templates/* roles/fs-drift/tasks/*
-
-# Build new ripsaw image
-update_operator_image
-
-get_uuid test_fs_drift.sh
-uuid=`cat uuid`
-
-cd ..
-
-indexes="ripsaw-fs-drift-results ripsaw-fs-drift-rsptimes ripsaw-fs-drift-rates-over-time"
-check_es "${uuid}" "${indexes}"
-exit $?
+pushd ripsaw
+source tests/test_fs_drift.sh

--- a/src/hammerdb/ci_test.sh
+++ b/src/hammerdb/ci_test.sh
@@ -5,23 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/hammerdb:master"
-image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/hammerdb:$SNAFU_IMAGE_TAG
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/hammerdb:$SNAFU_IMAGE_TAG 
 build_and_push src/hammerdb/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/hammerdb/templates/*
-
-# Build new ripsaw image
-update_operator_image
-
-get_uuid test_hammerdb.sh
-uuid=`cat uuid`
-
-cd ..
-
-index="ripsaw-hammerdb-results"
-
-check_es "${uuid}" "${index}"
-exit $?
+pushd ripsaw
+source tests/test_hammerdb.sh

--- a/src/iperf/ci_test.sh
+++ b/src/iperf/ci_test.sh
@@ -5,18 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/iperf3:latest"
-image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/iperf3:$SNAFU_IMAGE_TAG
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/iperf3:$SNAFU_IMAGE_TAG 
 build_and_push src/iperf/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/iperf3/templates/*
-
-# Build new ripsaw image
-update_operator_image
-
-# iperf does not utilize a wrapper from snafu, only the Dockerfile
-# We will confirm that the test_iperf passes only
-bash tests/test_iperf3.sh 
-
+pushd ripsaw
+source tests/test_iperf3.sh

--- a/src/pgbench_wrapper/ci_test.sh
+++ b/src/pgbench_wrapper/ci_test.sh
@@ -5,25 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image="quay.io/cloud-bulldozer/pgbench"
-default_ripsaw_tag="latest"
-image=$SNAFU_WRAPPER_IMAGE_PREFIX/pgbench
-build_and_push src/pgbench_wrapper/Dockerfile $image:snafu_ci
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image#$image#" roles/pgbench/defaults/main.yml
-sed -i "s#$default_ripsaw_tag#$SNAFU_IMAGE_TAG#" roles/pgbench/defaults/main.yml
-
-# Build new ripsaw image
-update_operator_image
-
-get_uuid test_pgbench.sh
-uuid=`cat uuid`
-
-cd ..
-
-index="ripsaw-pgbench-summary ripsaw-pgbench-raw"
-
-check_es "${uuid}" "${index}"
-exit $?
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/pgbench:$SNAFU_IMAGE_TAG
+build_and_push src/pgbench_wrapper/Dockerfile $image_spec
+pushd ripsaw
+source tests/test_pgbench.sh

--- a/src/smallfile_wrapper/ci_test.sh
+++ b/src/smallfile_wrapper/ci_test.sh
@@ -5,24 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/smallfile:master"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/smallfile:$SNAFU_IMAGE_TAG
 build_and_push src/smallfile_wrapper/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/smallfile/templates/* roles/smallfile/tasks/*
-
-# Build new ripsaw image
-update_operator_image
-
-get_uuid test_smallfile.sh
-uuid=`cat uuid`
-
-cd ..
-
-index="ripsaw-smallfile-results ripsaw-smallfile-rsptimes"
-
-check_es "${uuid}" "${index}"
-exit $?
-
+pushd ripsaw
+source tests/test_smallfile.sh

--- a/src/sysbench/ci_test.sh
+++ b/src/sysbench/ci_test.sh
@@ -5,17 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/sysbench:latest"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/sysbench:$SNAFU_IMAGE_TAG
 build_and_push src/sysbench/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/sysbench/templates/*
-
-# Build new ripsaw image
-update_operator_image
-
-# sysbench does not utilize a wrapper from snafu, only the Dockerfile
-# We will confirm that the test_sysbench passes only
-bash tests/test_sysbench.sh 
+pushd ripsaw
+source tests/test_sysbench.sh

--- a/src/uperf_wrapper/ci_test.sh
+++ b/src/uperf_wrapper/ci_test.sh
@@ -5,23 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/uperf:latest"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/uperf:$SNAFU_IMAGE_TAG
 build_and_push src/uperf_wrapper/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -si "s#$default_ripsaw_image_spec#$image_spec#g" roles/uperf/templates/*
-
-# Build new ripsaw image
-update_operator_image
-
-get_uuid test_uperf.sh
-uuid=`cat uuid`
-
-cd ..
-
-index="ripsaw-uperf-results"
-
-check_es "${uuid}" "${index}"
-exit $?
+pushd ripsaw
+source tests/test_uperf.sh

--- a/src/vegeta_wrapper/ci_test.sh
+++ b/src/vegeta_wrapper/ci_test.sh
@@ -5,13 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/vegeta:lastest"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/vegeta:$SNAFU_IMAGE_TAG
 build_and_push src/vegeta_wrapper/Dockerfile $image_spec
-
 pushd ripsaw
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/vegeta/templates/*
-# Build new ripsaw image
-update_operator_image
-source ./tests/test_vegeta.sh
-popd
+source tests/test_vegeta.sh

--- a/src/ycsb_wrapper/ci_test.sh
+++ b/src/ycsb_wrapper/ci_test.sh
@@ -5,23 +5,7 @@ set -x
 source ci/common.sh
 
 # Build image for ci
-default_ripsaw_image_spec="quay.io/cloud-bulldozer/ycsb-server:latest"
 image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/ycsb-server:$SNAFU_IMAGE_TAG
 build_and_push src/ycsb_wrapper/Dockerfile $image_spec
-
-cd ripsaw
-
-sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/ycsb/templates/*
-
-# Build new ripsaw image
-update_operator_image
-
-get_uuid test_ycsb.sh
-uuid=`cat uuid`
-
-cd ..
-
-index="ripsaw-ycsb-summary ripsaw-ycsb-results"
-
-check_es "${uuid}" "${index}"
-exit $?
+pushd ripsaw
+source tests/test_ycsb.sh


### PR DESCRIPTION
Would fix https://github.com/cloud-bulldozer/snafu/issues/186 along with avoid rebuilding and pushing ripsaw in each test.

Also simplifies the function wait_clean since deleting a namespace waits for the deletion of all  objects within it by default.

Rather than doing all those "sed" invocations, we might use the image argument of the benchmark YAMLs to overwrite the image. However I'm not sure about that idea since we would have to reference each test benchmark CRD.
Thoughts?