### PR TITLE
Add vegeta wrapper

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -9,7 +9,7 @@ rm -rf ripsaw
 git clone https://github.com/cloud-bulldozer/ripsaw.git --depth 1
 
 if [[ $ghprbPullLongDescription = *"Depends-On:"* ]]; then
-  ripsaw_change_id="$(echo $ghprbPullLongDescription | sed -n -e 's/^.*Depends-On: //p')"
+  ripsaw_change_id="$(echo -e $ghprbPullLongDescription | sed -n -e 's/^.*Depends-On: //p' | dos2unix)"
   echo $ripsaw_change_id
   cd ripsaw
   git fetch origin pull/$ripsaw_change_id/head:local_change

--- a/run_snafu.py
+++ b/run_snafu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/run_snafu.py
+++ b/run_snafu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -87,7 +87,7 @@ def main():
             logger.info("Connected to the elasticsearch cluster with info as follows:{0}".format(
                 str(es.info())))
         except Exception as e:
-            logger.warn("Elasticsearch connection caused an exception : %s" % e)
+            logger.warning("Elasticsearch connection caused an exception : %s" % e)
             index_args.index_results = False
 
     index_args.document_size_capacity_bytes = 0

--- a/uperf_wrapper/trigger_uperf.py
+++ b/uperf_wrapper/trigger_uperf.py
@@ -78,9 +78,9 @@ class Trigger_uperf():
 
     def _run_uperf(self):
         cmd = "uperf -v -a -x -i 1 -m {}".format(self.workload)
-        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
-        return stdout.strip().decode("utf-8"), stderr, process.returncode
+        return stdout.strip().decode("utf-8"), stderr.strip().decode("utf-8"), process.returncode
 
     def _parse_stdout(self, stdout):
         # This will effectivly give us:
@@ -107,8 +107,12 @@ class Trigger_uperf():
             if rc == 1:
                 logger.error("UPerf failed to execute, trying one more time..")
                 stdout, stderr, rc = self._run_uperf()
+                logger.error("stdout: %s" % stdout)
+                logger.error("stderr: %s" % stderr)
                 if rc == 1:
                     logger.critical("UPerf failed to execute a second time, stopping...")
+                    logger.critical("stdout: %s" % stdout)
+                    logger.critical("stderr: %s" % stderr)
                     exit(1)
             data = self._parse_stdout(stdout)
             documents = self._json_payload(data, s)

--- a/utils/wrapper_factory.py
+++ b/utils/wrapper_factory.py
@@ -8,6 +8,7 @@ from fs_drift_wrapper.fs_drift_wrapper import fs_drift_wrapper
 from cluster_loader.cluster_loader import cluster_loader_wrapper
 from hammerdb.hammerdb_wrapper import hammerdb_wrapper
 from ycsb_wrapper.ycsb_wrapper import ycsb_wrapper
+from vegeta_wrapper.vegeta_wrapper import vegeta_wrapper
 
 import logging
 logger = logging.getLogger("snafu")
@@ -20,7 +21,8 @@ wrapper_dict = {
     "hammerdb": hammerdb_wrapper,
     "ycsb": ycsb_wrapper,
     "uperf": uperf_wrapper,
-    "pgbench": pgbench_wrapper
+    "pgbench": pgbench_wrapper,
+    "vegeta": vegeta_wrapper
 }
 #    "backpack": pgbench_wrapper,
 #    "fio": fio_wrapper,

--- a/vegeta_wrapper/Dockerfile
+++ b/vegeta_wrapper/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs python3 python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.3/vegeta-12.8.3-linux-amd64.tar.gz | tar xz -C /usr/bin/ vegeta
+RUN mkdir -p /opt/snafu/
+COPY requirements.txt /opt/snafu/requirements.txt
+RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt
+COPY . /opt/snafu/

--- a/vegeta_wrapper/Dockerfile
+++ b/vegeta_wrapper/Dockerfile
@@ -4,6 +4,7 @@ COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.r
 RUN dnf install -y --nodocs python3 python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.3/vegeta-12.8.3-linux-amd64.tar.gz | tar xz -C /usr/bin/ vegeta
+RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY requirements.txt /opt/snafu/requirements.txt
 RUN pip3 install --upgrade-strategy=only-if-needed -r /opt/snafu/requirements.txt

--- a/vegeta_wrapper/ci_test.sh
+++ b/vegeta_wrapper/ci_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+default_ripsaw_image_spec="quay.io/cloud-bulldozer/vegeta:lastest"
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/vegeta:$SNAFU_IMAGE_TAG
+build_and_push vegeta_wrapper/Dockerfile $image_spec
+
+pushd ripsaw
+sed -i "s#$default_ripsaw_image_spec#$image_spec#g" roles/vegeta/templates/*
+# Build new ripsaw image
+update_operator_image
+source ./tests/test_vegeta.sh
+popd

--- a/vegeta_wrapper/trigger_vegeta.py
+++ b/vegeta_wrapper/trigger_vegeta.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import os
+import subprocess
+import json
+import socket
+import dateutil.parser
+import logging
+
+logger = logging.getLogger("snafu")
+
+
+class Trigger_vegeta():
+    def __init__(self, args):
+        self.uuid = args.uuid
+        self.user = args.user
+        self.sample = args.sample
+        self.workers = args.workers
+        self.targets = args.targets
+        self.duration = args.duration
+        self.cluster_name = args.cluster_name
+        self.keepalive = args.keepalive
+
+    def _json_payload(self, data, sample):
+        payload = {
+            "workload": "vegeta",
+            "uuid": self.uuid,
+            "user": self.user,
+            "cluster_name": self.cluster_name,
+            "iteration": sample,
+            "duration": self.duration,
+            "workers": self.workers,
+            "keepalive": self.keepalive,
+            "targets": self.targets,
+            "hostname": socket.gethostname()
+        }
+        payload.update(data)
+        return payload
+
+    def _run_vegeta(self):
+        cmd = (
+            "vegeta attack -keepalive={0} -insecure -workers={1} -duration={2}s -targets={3} -rate=0"
+            " -max-workers={1} | vegeta report --every=1s --type=json --output=vegeta.log").format(
+            self.keepalive, self.workers, self.duration, self.targets)
+        logger.info(cmd)
+        p = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return p.stdout.strip().decode("utf-8"), p.stderr.strip().decode("utf-8"), p.returncode
+
+    def _parse_stdout(self):
+        status_codes = {}
+        status_codes_bck = {}
+        bytes_in_bck = 0
+        bytes_out_bck = 0
+        for l in open("vegeta.log").readlines():
+            data = json.loads(l)
+            rps = int(data["rate"])
+            throughput = int(data["throughput"])
+            for s, n in data["status_codes"].items():
+                if s in status_codes_bck:
+                    status_codes[s] = n - status_codes_bck[s]
+                else:
+                    status_codes[s] = n
+                status_codes_bck[s] = n
+            bytes_in = data["bytes_in"]["total"] - bytes_in_bck
+            bytes_in_bck = data["bytes_in"]["total"]
+            bytes_out = data["bytes_out"]["total"] - bytes_out_bck
+            bytes_out_bck = data["bytes_out"]["total"]
+            # Latency units are reported in nanoseconds. We convert them here to usecs
+            p99 = int(data["latencies"]["99th"] / 1000)
+            ltcy = int(data["latencies"]["mean"] / 1000)
+            ts = dateutil.parser.parse(data["end"])
+            yield {
+                "rps": rps,
+                "throughput": throughput,
+                "status_codes": status_codes,
+                "requests": data["requests"],
+                "p99_latency": p99,
+                "req_latency": ltcy,
+                "timestamp": ts,
+                "bytes_in": bytes_in,
+                "bytes_out": bytes_out
+            }
+
+    def emit_actions(self):
+        if not os.path.exists(self.targets):
+            logger.critical("Targets file %s not found" % self.targets)
+            exit(1)
+        for s in range(1, self.sample + 1):
+            logger.info("Starting vegeta sample %d out of %d with uuid %s" % (s, self.sample, self.uuid))
+            stdout, stderr, rc = self._run_vegeta()
+            if rc:
+                logger.critical("Vegeta failed with returncode %d, stopping benchmark" % rc)
+                logger.error("stdout: %s" % stdout)
+                logger.error("stderr: %s" % stderr)
+                exit(1)
+            for data in self._parse_stdout():
+                es_data = self._json_payload(data, s)
+                yield es_data, 'results'
+            logger.info("Finished executing vegeta sample %d out of %d" % (s, self.sample))

--- a/vegeta_wrapper/trigger_vegeta.py
+++ b/vegeta_wrapper/trigger_vegeta.py
@@ -42,7 +42,7 @@ class Trigger_vegeta():
             "duration": self.duration,
             "workers": self.workers,
             "keepalive": self.keepalive,
-            "targets": self.targets,
+            "targets": os.path.basename(self.targets),
             "hostname": socket.gethostname()
         }
         payload.update(data)
@@ -101,8 +101,8 @@ class Trigger_vegeta():
             stdout, stderr, rc = self._run_vegeta()
             if rc:
                 logger.critical("Vegeta failed with returncode %d, stopping benchmark" % rc)
-                logger.error("stdout: %s" % stdout)
-                logger.error("stderr: %s" % stderr)
+                logger.critical("stdout: %s" % stdout)
+                logger.critical("stderr: %s" % stderr)
                 exit(1)
             for data in self._parse_stdout():
                 es_data = self._json_payload(data, s)

--- a/vegeta_wrapper/vegeta_wrapper.py
+++ b/vegeta_wrapper/vegeta_wrapper.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import os
+import argparse
+from vegeta_wrapper.trigger_vegeta import Trigger_vegeta
+
+
+class vegeta_wrapper():
+
+    def __init__(self, parent_parser):
+        parser_object = argparse.ArgumentParser(description="Vegeta Wrapper script", parents=[parent_parser],
+                                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser = parser_object.add_argument_group("Vegeta benchmark")
+        parser.add_argument(
+            '--targets',
+            help='Targets file in http format', required=True)
+        parser.add_argument(
+            '-w', '--workers',
+            default=1,
+            type=int,
+            help='Provide the number of workers for vegeta')
+        parser.add_argument(
+            '-u', '--uuid',
+            required=True,
+            help='Provide the uuid')
+        parser.add_argument(
+            '-d', '--duration',
+            default="30",
+            type=int,
+            help='Provide the duration of the test in seconds')
+        parser.add_argument(
+            '--user',
+            default="snafu",
+            help='Enter the user')
+        parser.add_argument(
+            '--keepalive',
+            action="store_true",
+            help='Use TCP keep-alive')
+        parser.add_argument(
+            '-s', '--sample',
+            type=int,
+            default=1,
+            help='Number of times to run the benchmark')
+        self.args = parser_object.parse_args()
+
+        self.args.cluster_name = os.getenv("clustername", "mycluster")
+
+    def run(self):
+        yield Trigger_vegeta(self.args)


### PR DESCRIPTION
Depends-On: 359

It includes the following options:
```console
usage: run_snafu.py [-h] [-v] -t TOOL --targets TARGETS [-w WORKERS] -u UUID [-d DURATION] [--user USER] [--keepalive] [-s SAMPLE]

Vegeta Wrapper script

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         enables verbose wrapper debugging info (default: 20)
  -t TOOL, --tool TOOL  Provide tool name (default: None)

Vegeta benchmark:
  --targets TARGETS     Targets file in http format (default: None)
  -w WORKERS, --workers WORKERS
                        Provide the number of workers for vegeta (default: 1)
  -u UUID, --uuid UUID  Provide the uuid (default: None)
  -d DURATION, --duration DURATION
                        Provide the duration of the test in seconds (default: 30)
  --user USER           Enter the user (default: snafu)
  --keepalive           Use TCP keep-alive (default: False)
  -s SAMPLE, --sample SAMPLE
                        Number of times to run the benchmark (default: 1)
```

Can be tested with:
```console
$ cat > targets <<< "GET https://1.1.1.1
GET http://nginx-pass-net-scale.apps.rsevilla.perf.ocp.com"
$ export es=myes.com es_port=9200 es_index=vegeta
$ python run_snafu.py -t vegeta --targets targets -u $(uuidgen) -d 30 -w 5 -s 1
2020-06-10T10:53:47Z - INFO     - MainProcess - run_snafu: logging level is INFO
2020-06-10T10:53:47Z - INFO     - MainProcess - run_snafu: Using elasticsearch server with host:https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com                                                               
2020-06-10T10:53:47Z - INFO     - MainProcess - run_snafu: Using elasticsearch server with port:443
2020-06-10T10:53:47Z - INFO     - MainProcess - run_snafu: Using index prefix for ES:vegeta                            
2020-06-10T10:53:48Z - INFO     - MainProcess - run_snafu: Connected to the elasticsearch cluster with info as follows:{'name': '8a53754502eeb862d764feedfc0b4db9', 'cluster_name': '925374498059:cloud-perf', 'cluster_uuid': '6uuXpWTAT9q_9R
8GApbrNA', 'version': {'number': '7.1.1', 'build_flavor': 'oss', 'build_type': 'tar', 'build_hash': '7a013de', 'build_date': '2019-09-05T07:25:23.525600Z', 'build_snapshot': False, 'lucene_version': '8.0.0', 'minimum_wire_compatibility_ve
rsion': '6.8.0', 'minimum_index_compatibility_version': '6.0.0-beta1'}, 'tagline': 'You Know, for Search'}
2020-06-10T10:53:48Z - INFO     - MainProcess - wrapper_factory: identified vegeta as the benchmark wrapper            
2020-06-10T10:53:48Z - INFO     - MainProcess - trigger_vegeta: Starting vegeta sample 1 out of 1 with uuid a5223fac-4b30-4d66-aa48-b71eb9588d5f
2020-06-10T10:53:48Z - INFO     - MainProcess - trigger_vegeta: vegeta attack -keepalive=False -insecure -workers=5 -duration=30s -targets=targets -rate=0 -max-workers=5 | vegeta report --every=1s --type=json --output=vegeta.log
2020-06-10T10:54:18Z - INFO     - MainProcess - trigger_vegeta: Finished executing vegeta sample 1 out of 1
2020-06-10T10:54:18Z - INFO     - MainProcess - run_snafu: Indexed results - 27 success, 0 duplicates, 0 failures, with 0 retries. 
2020-06-10T10:54:19Z - INFO     - MainProcess - run_snafu: Duration of execution - 0:00:30, with total size of 6264 bytes
```
---

**Metrics indexed at 1 second intervals**
- rps:  Rate of sent requests per second.
- throughput: Rate of successful requests per second.
- status_codes: Breakdown of the number status codes observed over the interval.
- requests: Total number of requests executed until that moment.
- p99_latency: 99th percentile of the request latency observed over the interval in µs
- req_latency: Average latency of all requests observed over the interval in µs
- timestamp
- bytes_in: Incoming byte metrics over the interval
- bytes_out: Outgoing byte metrics over the interval
- targets: Targets file used
- iteration: Iteration number
- workers: Number of workers
- hostname: Hostname from the host where the test is launched.
- keepalive: Whether keepalive is used or not
