### PR TITLE
Add python-dateutil to requirements for vegeta

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 pyyaml
 requests
 redis
+python-dateutil


### PR DESCRIPTION
python-dateutil is required by vegeta_wrapper/trigger_vegeta.py

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>