### PR TITLE
Replace pbench-uperf by epel's uperf

### DIFF
--- a/uperf_wrapper/Dockerfile
+++ b/uperf_wrapper/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8:latest
 RUN dnf install -y --nodocs git python3-pip && dnf clean all
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
-RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
+RUN dnf install -y --nodocs hostname procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
 RUN dnf install -y uperf && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/

--- a/uperf_wrapper/Dockerfile
+++ b/uperf_wrapper/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf copr enable ndokos/pbench -y
-RUN dnf install -y --nodocs git python3-pip pbench-uperf
+RUN dnf install -y --nodocs git python3-pip && dnf clean all
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
-RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
+RUN dnf install -y uperf && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/uperf_wrapper/trigger_uperf.py
+++ b/uperf_wrapper/trigger_uperf.py
@@ -77,7 +77,7 @@ class Trigger_uperf():
         return processed
 
     def _run_uperf(self):
-        cmd = "uperf -v -a -x -i 1 -m {}".format(self.workload)
+        cmd = "uperf -v -a -R -i 1 -m {}".format(self.workload)
         process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
         return stdout.strip().decode("utf-8"), stderr.strip().decode("utf-8"), process.returncode


### PR DESCRIPTION
Depends-on: 367

pbench-uperf seems to be no longer available. EPEL's version is 1.0.7.
```console
$ uperf  -h | grep '\-R'
        -R               Emit raw (not transformed), time-stamped (ms) statistics
```